### PR TITLE
[TASK] 시청 세션 도메인 모델 설계

### DIFF
--- a/.idea/modules/springProject.main.iml
+++ b/.idea/modules/springProject.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../springProject/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../springProject/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/springProject/src/main/java/com/teambind/springproject/common/config/RedisConfig.java
+++ b/springProject/src/main/java/com/teambind/springproject/common/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.teambind.springproject.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 설정 클래스.
+ */
+@Configuration
+public class RedisConfig {
+
+  /**
+   * RedisTemplate 빈 설정.
+   * Key는 String, Value는 JSON 직렬화를 사용한다.
+   *
+   * @param connectionFactory Redis 연결 팩토리
+   * @return RedisTemplate 인스턴스
+   */
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(
+      final RedisConnectionFactory connectionFactory
+  ) {
+    RedisTemplate<String, Object> template = new RedisTemplate<>();
+    template.setConnectionFactory(connectionFactory);
+
+    // Key는 String 직렬화
+    template.setKeySerializer(new StringRedisSerializer());
+    template.setHashKeySerializer(new StringRedisSerializer());
+
+    // Value는 JSON 직렬화
+    GenericJackson2JsonRedisSerializer jsonSerializer =
+        new GenericJackson2JsonRedisSerializer();
+    template.setValueSerializer(jsonSerializer);
+    template.setHashValueSerializer(jsonSerializer);
+
+    template.afterPropertiesSet();
+    return template;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/entity/WatchSession.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/entity/WatchSession.java
@@ -1,0 +1,194 @@
+package com.teambind.springproject.domain.session.entity;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * 동영상 시청 세션을 나타내는 도메인 객체.
+ * Redis에 저장되어 활성 세션을 관리한다.
+ */
+public class WatchSession implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final Long sessionId;
+  private final Long userId;
+  private final Long contentId;
+  private final LocalDateTime startedAt;
+  private LocalDateTime lastActiveAt;
+  private WatchSessionStatus status;
+  private Integer lastPositionSeconds;
+
+  private WatchSession(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final LocalDateTime startedAt,
+      final LocalDateTime lastActiveAt,
+      final WatchSessionStatus status,
+      final Integer lastPositionSeconds
+  ) {
+    this.sessionId = sessionId;
+    this.userId = userId;
+    this.contentId = contentId;
+    this.startedAt = startedAt;
+    this.lastActiveAt = lastActiveAt;
+    this.status = status;
+    this.lastPositionSeconds = lastPositionSeconds;
+  }
+
+  /**
+   * 새로운 시청 세션을 생성한다.
+   *
+   * @param sessionId 세션 ID (Snowflake로 생성)
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 새로운 WatchSession 인스턴스
+   */
+  public static WatchSession create(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId
+  ) {
+    LocalDateTime now = LocalDateTime.now();
+    return new WatchSession(
+        sessionId,
+        userId,
+        contentId,
+        now,
+        now,
+        WatchSessionStatus.ACTIVE,
+        0
+    );
+  }
+
+  /**
+   * 저장된 세션을 복원한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param startedAt 시작 시간
+   * @param lastActiveAt 마지막 활성 시간
+   * @param status 상태
+   * @param lastPositionSeconds 마지막 시청 위치
+   * @return WatchSession 인스턴스
+   */
+  public static WatchSession restore(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final LocalDateTime startedAt,
+      final LocalDateTime lastActiveAt,
+      final WatchSessionStatus status,
+      final Integer lastPositionSeconds
+  ) {
+    return new WatchSession(
+        sessionId,
+        userId,
+        contentId,
+        startedAt,
+        lastActiveAt,
+        status,
+        lastPositionSeconds
+    );
+  }
+
+  /**
+   * 시청 진행 상황을 업데이트한다.
+   *
+   * @param positionSeconds 현재 시청 위치 (초)
+   */
+  public void updateProgress(final Integer positionSeconds) {
+    validateActiveSession();
+    this.lastPositionSeconds = positionSeconds;
+    this.lastActiveAt = LocalDateTime.now();
+  }
+
+  /**
+   * 세션을 정상 종료한다.
+   */
+  public void terminate() {
+    this.status = WatchSessionStatus.TERMINATED;
+    this.lastActiveAt = LocalDateTime.now();
+  }
+
+  /**
+   * 다른 콘텐츠 시청으로 인해 세션을 종료한다.
+   */
+  public void replace() {
+    this.status = WatchSessionStatus.REPLACED;
+    this.lastActiveAt = LocalDateTime.now();
+  }
+
+  /**
+   * 타임아웃으로 세션을 종료한다.
+   */
+  public void timeout() {
+    this.status = WatchSessionStatus.TIMEOUT;
+  }
+
+  /**
+   * 세션이 활성 상태인지 확인한다.
+   *
+   * @return 활성 상태이면 true
+   */
+  public boolean isActive() {
+    return status.isActive();
+  }
+
+  /**
+   * 해당 사용자의 세션인지 확인한다.
+   *
+   * @param userId 확인할 사용자 ID
+   * @return 해당 사용자의 세션이면 true
+   */
+  public boolean belongsTo(final Long userId) {
+    return this.userId.equals(userId);
+  }
+
+  /**
+   * 해당 콘텐츠의 세션인지 확인한다.
+   *
+   * @param contentId 확인할 콘텐츠 ID
+   * @return 해당 콘텐츠의 세션이면 true
+   */
+  public boolean isForContent(final Long contentId) {
+    return this.contentId.equals(contentId);
+  }
+
+  private void validateActiveSession() {
+    if (!isActive()) {
+      throw new IllegalStateException("비활성 세션에서는 진행 상황을 업데이트할 수 없습니다.");
+    }
+  }
+
+  // Getters
+  public Long getSessionId() {
+    return sessionId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public LocalDateTime getStartedAt() {
+    return startedAt;
+  }
+
+  public LocalDateTime getLastActiveAt() {
+    return lastActiveAt;
+  }
+
+  public WatchSessionStatus getStatus() {
+    return status;
+  }
+
+  public Integer getLastPositionSeconds() {
+    return lastPositionSeconds;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/entity/WatchSessionStatus.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/entity/WatchSessionStatus.java
@@ -1,0 +1,46 @@
+package com.teambind.springproject.domain.session.entity;
+
+/**
+ * 시청 세션 상태를 나타내는 enum.
+ */
+public enum WatchSessionStatus {
+
+  /**
+   * 활성 상태 - 현재 시청 중.
+   */
+  ACTIVE("활성"),
+
+  /**
+   * 종료됨 - 정상적으로 세션 종료.
+   */
+  TERMINATED("종료"),
+
+  /**
+   * 타임아웃 - 일정 시간 응답 없음으로 자동 종료.
+   */
+  TIMEOUT("타임아웃"),
+
+  /**
+   * 강제 종료 - 다른 콘텐츠 시청으로 인한 종료.
+   */
+  REPLACED("대체됨");
+
+  private final String description;
+
+  WatchSessionStatus(final String description) {
+    this.description = description;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * 세션이 활성 상태인지 확인.
+   *
+   * @return 활성 상태이면 true
+   */
+  public boolean isActive() {
+    return this == ACTIVE;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/repository/RedisWatchSessionRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/repository/RedisWatchSessionRepository.java
@@ -1,0 +1,88 @@
+package com.teambind.springproject.domain.session.repository;
+
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Redis 기반 시청 세션 저장소 구현체.
+ */
+@Repository
+public class RedisWatchSessionRepository implements WatchSessionRepository {
+
+  private static final String SESSION_KEY_PREFIX = "watch:session:";
+  private static final String USER_ACTIVE_SESSION_KEY_PREFIX = "watch:user:active:";
+  private static final long DEFAULT_TTL_SECONDS = 30;
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public RedisWatchSessionRepository(final RedisTemplate<String, Object> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  @Override
+  public void save(final WatchSession session) {
+    String sessionKey = getSessionKey(session.getSessionId());
+    String userActiveKey = getUserActiveSessionKey(session.getUserId());
+
+    redisTemplate.opsForValue().set(sessionKey, session, DEFAULT_TTL_SECONDS, TimeUnit.SECONDS);
+
+    if (session.isActive()) {
+      redisTemplate.opsForValue().set(
+          userActiveKey,
+          session.getSessionId(),
+          DEFAULT_TTL_SECONDS,
+          TimeUnit.SECONDS
+      );
+    }
+  }
+
+  @Override
+  public Optional<WatchSession> findById(final Long sessionId) {
+    String key = getSessionKey(sessionId);
+    Object value = redisTemplate.opsForValue().get(key);
+    if (value instanceof WatchSession) {
+      return Optional.of((WatchSession) value);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<WatchSession> findActiveByUserId(final Long userId) {
+    String userActiveKey = getUserActiveSessionKey(userId);
+    Object sessionIdObj = redisTemplate.opsForValue().get(userActiveKey);
+
+    if (sessionIdObj instanceof Long sessionId) {
+      return findById(sessionId);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void delete(final Long sessionId) {
+    String key = getSessionKey(sessionId);
+    redisTemplate.delete(key);
+  }
+
+  @Override
+  public void deleteActiveByUserId(final Long userId) {
+    String userActiveKey = getUserActiveSessionKey(userId);
+    redisTemplate.delete(userActiveKey);
+  }
+
+  @Override
+  public void refreshTtl(final Long sessionId, final long ttlSeconds) {
+    String key = getSessionKey(sessionId);
+    redisTemplate.expire(key, ttlSeconds, TimeUnit.SECONDS);
+  }
+
+  private String getSessionKey(final Long sessionId) {
+    return SESSION_KEY_PREFIX + sessionId;
+  }
+
+  private String getUserActiveSessionKey(final Long userId) {
+    return USER_ACTIVE_SESSION_KEY_PREFIX + userId;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/repository/WatchSessionRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/repository/WatchSessionRepository.java
@@ -1,0 +1,56 @@
+package com.teambind.springproject.domain.session.repository;
+
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import java.util.Optional;
+
+/**
+ * 시청 세션 저장소 인터페이스.
+ * Redis 기반 구현체에서 활성 세션을 관리한다.
+ */
+public interface WatchSessionRepository {
+
+  /**
+   * 세션을 저장한다.
+   *
+   * @param session 저장할 세션
+   */
+  void save(WatchSession session);
+
+  /**
+   * 세션 ID로 세션을 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 세션 (Optional)
+   */
+  Optional<WatchSession> findById(Long sessionId);
+
+  /**
+   * 사용자의 현재 활성 세션을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @return 활성 세션 (Optional)
+   */
+  Optional<WatchSession> findActiveByUserId(Long userId);
+
+  /**
+   * 세션을 삭제한다.
+   *
+   * @param sessionId 세션 ID
+   */
+  void delete(Long sessionId);
+
+  /**
+   * 사용자의 활성 세션을 삭제한다.
+   *
+   * @param userId 사용자 ID
+   */
+  void deleteActiveByUserId(Long userId);
+
+  /**
+   * 세션 TTL을 갱신한다.
+   *
+   * @param sessionId 세션 ID
+   * @param ttlSeconds TTL (초)
+   */
+  void refreshTtl(Long sessionId, long ttlSeconds);
+}


### PR DESCRIPTION
## Summary
시청 세션 도메인 모델 설계 완료. Redis 기반 활성 세션 관리 구조 구현.

## Changes
- WatchSessionStatus enum 추가 (ACTIVE, TERMINATED, TIMEOUT, REPLACED)
- WatchSession 도메인 객체 추가 (Factory Method 패턴)
- WatchSessionRepository 인터페이스 정의
- RedisWatchSessionRepository 구현체 추가
- RedisConfig 설정 클래스 추가

## Related Issues
Closes #9

## Test Plan
- [ ] Redis 연결 후 세션 저장/조회 테스트
- [ ] TTL 만료 테스트
- [ ] 사용자별 활성 세션 관리 테스트