### PR TITLE
[TASK] 시청 세션 관리 API 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/session/controller/WatchSessionController.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/controller/WatchSessionController.java
@@ -1,0 +1,94 @@
+package com.teambind.springproject.domain.session.controller;
+
+import com.teambind.springproject.domain.session.dto.SessionResponse;
+import com.teambind.springproject.domain.session.dto.SessionStartRequest;
+import com.teambind.springproject.domain.session.service.WatchSessionService;
+import jakarta.validation.Valid;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 시청 세션 관리 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/sessions")
+public class WatchSessionController {
+
+  private final WatchSessionService sessionService;
+
+  public WatchSessionController(final WatchSessionService sessionService) {
+    this.sessionService = sessionService;
+  }
+
+  /**
+   * 시청 세션을 시작한다.
+   * 기존 활성 세션이 있으면 자동으로 종료된다.
+   *
+   * @param request 세션 시작 요청
+   * @return 생성된 세션 정보
+   */
+  @PostMapping
+  public ResponseEntity<SessionResponse> startSession(
+      @Valid @RequestBody final SessionStartRequest request
+  ) {
+    SessionResponse response = sessionService.startSession(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * 시청 세션을 종료한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @return 204 No Content
+   */
+  @DeleteMapping("/{sessionId}")
+  public ResponseEntity<Void> endSession(
+      @PathVariable final Long sessionId,
+      @RequestParam final Long userId
+  ) {
+    sessionService.endSession(sessionId, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  /**
+   * 세션 정보를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 세션 정보
+   */
+  @GetMapping("/{sessionId}")
+  public ResponseEntity<SessionResponse> getSession(
+      @PathVariable final Long sessionId
+  ) {
+    Optional<SessionResponse> response = sessionService.getSession(sessionId);
+    return response
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  /**
+   * 사용자의 현재 활성 세션을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @return 활성 세션 정보
+   */
+  @GetMapping("/active")
+  public ResponseEntity<SessionResponse> getActiveSession(
+      @RequestParam final Long userId
+  ) {
+    Optional<SessionResponse> response = sessionService.getActiveSession(userId);
+    return response
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/dto/SessionResponse.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/dto/SessionResponse.java
@@ -1,0 +1,37 @@
+package com.teambind.springproject.domain.session.dto;
+
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import com.teambind.springproject.domain.session.entity.WatchSessionStatus;
+import java.time.LocalDateTime;
+
+/**
+ * 시청 세션 응답 DTO.
+ */
+public record SessionResponse(
+    Long sessionId,
+    Long userId,
+    Long contentId,
+    LocalDateTime startedAt,
+    LocalDateTime lastActiveAt,
+    WatchSessionStatus status,
+    Integer lastPositionSeconds
+) {
+
+  /**
+   * WatchSession 엔티티로부터 응답 DTO를 생성한다.
+   *
+   * @param session 시청 세션
+   * @return SessionResponse
+   */
+  public static SessionResponse from(final WatchSession session) {
+    return new SessionResponse(
+        session.getSessionId(),
+        session.getUserId(),
+        session.getContentId(),
+        session.getStartedAt(),
+        session.getLastActiveAt(),
+        session.getStatus(),
+        session.getLastPositionSeconds()
+    );
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/dto/SessionStartRequest.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/dto/SessionStartRequest.java
@@ -1,0 +1,15 @@
+package com.teambind.springproject.domain.session.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 시청 세션 시작 요청 DTO.
+ */
+public record SessionStartRequest(
+    @NotNull(message = "사용자 ID는 필수입니다")
+    Long userId,
+
+    @NotNull(message = "콘텐츠 ID는 필수입니다")
+    Long contentId
+) {
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/service/WatchSessionService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/service/WatchSessionService.java
@@ -1,0 +1,113 @@
+package com.teambind.springproject.domain.session.service;
+
+import com.teambind.springproject.common.util.generator.PrimaryKeyGenerator;
+import com.teambind.springproject.domain.session.dto.SessionResponse;
+import com.teambind.springproject.domain.session.dto.SessionStartRequest;
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import com.teambind.springproject.domain.session.repository.WatchSessionRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+/**
+ * 시청 세션 관리 서비스.
+ */
+@Service
+public class WatchSessionService {
+
+  private final WatchSessionRepository sessionRepository;
+  private final PrimaryKeyGenerator keyGenerator;
+
+  public WatchSessionService(
+      final WatchSessionRepository sessionRepository,
+      final PrimaryKeyGenerator keyGenerator
+  ) {
+    this.sessionRepository = sessionRepository;
+    this.keyGenerator = keyGenerator;
+  }
+
+  /**
+   * 새로운 시청 세션을 시작한다.
+   * 기존 활성 세션이 있으면 종료하고 새 세션을 생성한다.
+   *
+   * @param request 세션 시작 요청
+   * @return 생성된 세션 응답
+   */
+  public SessionResponse startSession(final SessionStartRequest request) {
+    // 기존 활성 세션 종료
+    terminateExistingSession(request.userId());
+
+    // 새 세션 생성
+    Long sessionId = keyGenerator.generateLongKey();
+    WatchSession session = WatchSession.create(
+        sessionId,
+        request.userId(),
+        request.contentId()
+    );
+
+    sessionRepository.save(session);
+
+    return SessionResponse.from(session);
+  }
+
+  /**
+   * 세션을 종료한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID (세션 소유자 검증용)
+   */
+  public void endSession(final Long sessionId, final Long userId) {
+    Optional<WatchSession> sessionOpt = sessionRepository.findById(sessionId);
+
+    if (sessionOpt.isEmpty()) {
+      return;
+    }
+
+    WatchSession session = sessionOpt.get();
+
+    if (!session.belongsTo(userId)) {
+      throw new IllegalArgumentException("해당 세션에 대한 권한이 없습니다.");
+    }
+
+    session.terminate();
+    sessionRepository.save(session);
+    sessionRepository.deleteActiveByUserId(userId);
+  }
+
+  /**
+   * 사용자의 현재 활성 세션을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @return 활성 세션 응답 (Optional)
+   */
+  public Optional<SessionResponse> getActiveSession(final Long userId) {
+    return sessionRepository.findActiveByUserId(userId)
+        .map(SessionResponse::from);
+  }
+
+  /**
+   * 세션 ID로 세션을 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 세션 응답 (Optional)
+   */
+  public Optional<SessionResponse> getSession(final Long sessionId) {
+    return sessionRepository.findById(sessionId)
+        .map(SessionResponse::from);
+  }
+
+  /**
+   * 기존 활성 세션을 종료한다.
+   *
+   * @param userId 사용자 ID
+   */
+  private void terminateExistingSession(final Long userId) {
+    Optional<WatchSession> existingSession = sessionRepository.findActiveByUserId(userId);
+
+    if (existingSession.isPresent()) {
+      WatchSession session = existingSession.get();
+      session.replace();
+      sessionRepository.save(session);
+      sessionRepository.deleteActiveByUserId(userId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
시청 세션 관리 API 구현 완료. 세션 시작/종료/조회 기능 제공.

## Changes
- SessionStartRequest, SessionResponse DTO 추가
- WatchSessionService 비즈니스 로직 구현
- WatchSessionController REST API 구현

## API Endpoints
- POST /api/v1/sessions - 세션 시작 (기존 세션 자동 종료)
- DELETE /api/v1/sessions/{sessionId} - 세션 종료
- GET /api/v1/sessions/{sessionId} - 세션 조회
- GET /api/v1/sessions/active - 활성 세션 조회

## Related Issues
Closes #10

## Test Plan
- [ ] 세션 시작 API 테스트
- [ ] 기존 세션 자동 종료 테스트
- [ ] 세션 종료 API 테스트
- [ ] 세션 조회 API 테스트