### PR TITLE
[TASK] 시청 기록 저장 API 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/controller/ProgressController.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/controller/ProgressController.java
@@ -1,0 +1,62 @@
+package com.teambind.springproject.domain.progress.controller;
+
+import com.teambind.springproject.domain.progress.dto.ProgressReportRequest;
+import com.teambind.springproject.domain.progress.dto.ProgressResponse;
+import com.teambind.springproject.domain.progress.service.ProgressService;
+import jakarta.validation.Valid;
+import java.util.Optional;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 시청 진행 상황 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/progress")
+public class ProgressController {
+
+  private final ProgressService progressService;
+
+  public ProgressController(final ProgressService progressService) {
+    this.progressService = progressService;
+  }
+
+  /**
+   * 시청 진행 상황을 보고한다.
+   * 클라이언트에서 주기적으로(5초) 호출한다.
+   *
+   * @param request 진행 상황 보고 요청
+   * @return 업데이트된 진행 상황
+   */
+  @PostMapping
+  public ResponseEntity<ProgressResponse> reportProgress(
+      @Valid @RequestBody final ProgressReportRequest request
+  ) {
+    ProgressResponse response = progressService.reportProgress(request);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 콘텐츠별 진행 상황을 조회한다.
+   *
+   * @param contentId 콘텐츠 ID
+   * @param studentId 학생 ID
+   * @return 진행 상황
+   */
+  @GetMapping("/{contentId}")
+  public ResponseEntity<ProgressResponse> getProgress(
+      @PathVariable final Long contentId,
+      @RequestParam final Long studentId
+  ) {
+    Optional<ProgressResponse> response = progressService.getProgress(contentId, studentId);
+    return response
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/dto/ProgressReportRequest.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/dto/ProgressReportRequest.java
@@ -1,0 +1,24 @@
+package com.teambind.springproject.domain.progress.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 시청 진행 상황 보고 요청 DTO.
+ */
+public record ProgressReportRequest(
+    @NotNull(message = "세션 ID는 필수입니다")
+    Long sessionId,
+
+    @NotNull(message = "콘텐츠 ID는 필수입니다")
+    Long contentId,
+
+    @NotNull(message = "현재 위치는 필수입니다")
+    @Min(value = 0, message = "현재 위치는 0 이상이어야 합니다")
+    Integer currentPositionSeconds,
+
+    @NotNull(message = "전체 길이는 필수입니다")
+    @Min(value = 1, message = "전체 길이는 1 이상이어야 합니다")
+    Integer totalDurationSeconds
+) {
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/dto/ProgressResponse.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/dto/ProgressResponse.java
@@ -1,0 +1,42 @@
+package com.teambind.springproject.domain.progress.dto;
+
+import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import java.time.LocalDateTime;
+
+/**
+ * 시청 진행 상황 응답 DTO.
+ */
+public record ProgressResponse(
+    Long id,
+    Long contentId,
+    Long studentId,
+    Boolean isCompleted,
+    Integer progressPercentage,
+    Integer lastPositionSeconds,
+    LocalDateTime completedAt,
+    LocalDateTime firstAccessedAt,
+    LocalDateTime lastAccessedAt,
+    Integer accessCount
+) {
+
+  /**
+   * StudentContentProgress 엔티티로부터 응답 DTO를 생성한다.
+   *
+   * @param progress 학생 콘텐츠 진행 상황
+   * @return ProgressResponse
+   */
+  public static ProgressResponse from(final StudentContentProgress progress) {
+    return new ProgressResponse(
+        progress.getId(),
+        progress.getContentId(),
+        progress.getStudentId(),
+        progress.getIsCompleted(),
+        progress.getProgressPercentage(),
+        progress.getLastPositionSeconds(),
+        progress.getCompletedAt(),
+        progress.getFirstAccessedAt(),
+        progress.getLastAccessedAt(),
+        progress.getAccessCount()
+    );
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/entity/StudentContentProgress.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/entity/StudentContentProgress.java
@@ -1,0 +1,170 @@
+package com.teambind.springproject.domain.progress.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+
+/**
+ * 학생 콘텐츠 진행 상황 엔티티.
+ * LMS DB의 student_content_progress 테이블과 매핑.
+ */
+@Entity
+@Table(
+    name = "student_content_progress",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"content_id", "student_id"})
+    },
+    indexes = {
+        @Index(name = "idx_progress_content", columnList = "content_id"),
+        @Index(name = "idx_progress_student", columnList = "student_id"),
+        @Index(name = "idx_progress_completed", columnList = "is_completed")
+    }
+)
+public class StudentContentProgress {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "content_id", nullable = false)
+  private Long contentId;
+
+  @Column(name = "student_id", nullable = false)
+  private Long studentId;
+
+  @Column(name = "is_completed", nullable = false)
+  private Boolean isCompleted = false;
+
+  @Column(name = "progress_percentage", nullable = false)
+  private Integer progressPercentage = 0;
+
+  @Column(name = "last_position_seconds")
+  private Integer lastPositionSeconds;
+
+  @Column(name = "completed_at")
+  private LocalDateTime completedAt;
+
+  @Column(name = "first_accessed_at")
+  private LocalDateTime firstAccessedAt;
+
+  @Column(name = "last_accessed_at")
+  private LocalDateTime lastAccessedAt;
+
+  @Column(name = "access_count", nullable = false)
+  private Integer accessCount = 0;
+
+  protected StudentContentProgress() {
+  }
+
+  private StudentContentProgress(
+      final Long contentId,
+      final Long studentId
+  ) {
+    this.contentId = contentId;
+    this.studentId = studentId;
+    this.isCompleted = false;
+    this.progressPercentage = 0;
+    this.lastPositionSeconds = 0;
+    this.accessCount = 0;
+    this.firstAccessedAt = LocalDateTime.now();
+    this.lastAccessedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 새로운 진행 상황을 생성한다.
+   *
+   * @param contentId 콘텐츠 ID
+   * @param studentId 학생 ID
+   * @return StudentContentProgress 인스턴스
+   */
+  public static StudentContentProgress create(
+      final Long contentId,
+      final Long studentId
+  ) {
+    return new StudentContentProgress(contentId, studentId);
+  }
+
+  /**
+   * 시청 위치를 업데이트한다.
+   *
+   * @param positionSeconds 현재 시청 위치 (초)
+   * @param totalDurationSeconds 전체 영상 길이 (초)
+   * @param completionThreshold 완료 기준 퍼센트 (예: 90)
+   */
+  public void updateProgress(
+      final Integer positionSeconds,
+      final Integer totalDurationSeconds,
+      final int completionThreshold
+  ) {
+    this.lastPositionSeconds = positionSeconds;
+    this.lastAccessedAt = LocalDateTime.now();
+    this.accessCount++;
+
+    // 진행률 계산
+    if (totalDurationSeconds > 0) {
+      int newPercentage = (int) ((positionSeconds * 100.0) / totalDurationSeconds);
+      this.progressPercentage = Math.min(Math.max(newPercentage, this.progressPercentage), 100);
+    }
+
+    // 완료 처리
+    if (!this.isCompleted && this.progressPercentage >= completionThreshold) {
+      this.isCompleted = true;
+      this.completedAt = LocalDateTime.now();
+    }
+  }
+
+  /**
+   * 접근 횟수를 증가시킨다.
+   */
+  public void incrementAccessCount() {
+    this.accessCount++;
+    this.lastAccessedAt = LocalDateTime.now();
+  }
+
+  // Getters
+  public Long getId() {
+    return id;
+  }
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public Long getStudentId() {
+    return studentId;
+  }
+
+  public Boolean getIsCompleted() {
+    return isCompleted;
+  }
+
+  public Integer getProgressPercentage() {
+    return progressPercentage;
+  }
+
+  public Integer getLastPositionSeconds() {
+    return lastPositionSeconds;
+  }
+
+  public LocalDateTime getCompletedAt() {
+    return completedAt;
+  }
+
+  public LocalDateTime getFirstAccessedAt() {
+    return firstAccessedAt;
+  }
+
+  public LocalDateTime getLastAccessedAt() {
+    return lastAccessedAt;
+  }
+
+  public Integer getAccessCount() {
+    return accessCount;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/repository/StudentContentProgressRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/repository/StudentContentProgressRepository.java
@@ -1,0 +1,23 @@
+package com.teambind.springproject.domain.progress.repository;
+
+import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 학생 콘텐츠 진행 상황 Repository.
+ */
+@Repository
+public interface StudentContentProgressRepository
+    extends JpaRepository<StudentContentProgress, Long> {
+
+  /**
+   * 콘텐츠 ID와 학생 ID로 진행 상황을 조회한다.
+   *
+   * @param contentId 콘텐츠 ID
+   * @param studentId 학생 ID
+   * @return 진행 상황 (Optional)
+   */
+  Optional<StudentContentProgress> findByContentIdAndStudentId(Long contentId, Long studentId);
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/service/ProgressService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/service/ProgressService.java
@@ -1,0 +1,111 @@
+package com.teambind.springproject.domain.progress.service;
+
+import com.teambind.springproject.domain.progress.dto.ProgressReportRequest;
+import com.teambind.springproject.domain.progress.dto.ProgressResponse;
+import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import com.teambind.springproject.domain.progress.repository.StudentContentProgressRepository;
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import com.teambind.springproject.domain.session.repository.WatchSessionRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 시청 진행 상황 서비스.
+ */
+@Service
+public class ProgressService {
+
+  private final StudentContentProgressRepository progressRepository;
+  private final WatchSessionRepository sessionRepository;
+  private final int completionThreshold;
+  private final long sessionTimeoutSeconds;
+
+  public ProgressService(
+      final StudentContentProgressRepository progressRepository,
+      final WatchSessionRepository sessionRepository,
+      @Value("${learning.completion-threshold:90}") final int completionThreshold,
+      @Value("${watch.session.timeout-seconds:30}") final long sessionTimeoutSeconds
+  ) {
+    this.progressRepository = progressRepository;
+    this.sessionRepository = sessionRepository;
+    this.completionThreshold = completionThreshold;
+    this.sessionTimeoutSeconds = sessionTimeoutSeconds;
+  }
+
+  /**
+   * 시청 진행 상황을 보고한다.
+   *
+   * @param request 진행 상황 보고 요청
+   * @return 업데이트된 진행 상황 응답
+   */
+  @Transactional
+  public ProgressResponse reportProgress(final ProgressReportRequest request) {
+    // 세션 검증
+    WatchSession session = validateAndGetSession(request.sessionId());
+
+    // 콘텐츠 ID 일치 확인
+    if (!session.isForContent(request.contentId())) {
+      throw new IllegalArgumentException("세션의 콘텐츠 ID와 요청의 콘텐츠 ID가 일치하지 않습니다.");
+    }
+
+    // 세션 진행 상황 업데이트
+    session.updateProgress(request.currentPositionSeconds());
+    sessionRepository.save(session);
+    sessionRepository.refreshTtl(session.getSessionId(), sessionTimeoutSeconds);
+
+    // DB 진행 상황 업데이트
+    StudentContentProgress progress = getOrCreateProgress(
+        request.contentId(),
+        session.getUserId()
+    );
+
+    progress.updateProgress(
+        request.currentPositionSeconds(),
+        request.totalDurationSeconds(),
+        completionThreshold
+    );
+
+    progressRepository.save(progress);
+
+    return ProgressResponse.from(progress);
+  }
+
+  /**
+   * 콘텐츠별 진행 상황을 조회한다.
+   *
+   * @param contentId 콘텐츠 ID
+   * @param studentId 학생 ID
+   * @return 진행 상황 응답 (Optional)
+   */
+  @Transactional(readOnly = true)
+  public Optional<ProgressResponse> getProgress(final Long contentId, final Long studentId) {
+    return progressRepository.findByContentIdAndStudentId(contentId, studentId)
+        .map(ProgressResponse::from);
+  }
+
+  private WatchSession validateAndGetSession(final Long sessionId) {
+    Optional<WatchSession> sessionOpt = sessionRepository.findById(sessionId);
+
+    if (sessionOpt.isEmpty()) {
+      throw new IllegalArgumentException("세션을 찾을 수 없습니다.");
+    }
+
+    WatchSession session = sessionOpt.get();
+
+    if (!session.isActive()) {
+      throw new IllegalStateException("비활성 세션입니다. 새로운 세션을 시작해주세요.");
+    }
+
+    return session;
+  }
+
+  private StudentContentProgress getOrCreateProgress(
+      final Long contentId,
+      final Long studentId
+  ) {
+    return progressRepository.findByContentIdAndStudentId(contentId, studentId)
+        .orElseGet(() -> StudentContentProgress.create(contentId, studentId));
+  }
+}


### PR DESCRIPTION
## Summary
시청 기록 저장 API 구현 완료. 클라이언트에서 주기적으로 진행 상황을 보고하고 DB에 저장.

## Changes
- ProgressReportRequest, ProgressResponse DTO 추가
- StudentContentProgress 엔티티 추가 (LMS DB 매핑)
- StudentContentProgressRepository JPA Repository 추가
- ProgressService 비즈니스 로직 구현
- ProgressController REST API 구현

## API Endpoints
- POST /api/v1/progress - 시청 진행 상황 보고 (주기적 호출)
- GET /api/v1/progress/{contentId} - 콘텐츠별 진행 상황 조회

## Related Issues
Closes #11

## Test Plan
- [ ] 진행 상황 보고 API 테스트
- [ ] 세션 검증 테스트 (비활성 세션 거부)
- [ ] 진행률 계산 테스트
- [ ] 완료 기준(90%) 적용 테스트