### PR TITLE
#12 세션 타임아웃 처리 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/SpringProjectApplication.java
+++ b/springProject/src/main/java/com/teambind/springproject/SpringProjectApplication.java
@@ -3,6 +3,7 @@ package com.teambind.springproject;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * Video Service Application.
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * fraud detection, and learning progress tracking.
  */
 @SpringBootApplication
+@EnableAsync
 public class SpringProjectApplication {
 
   /**

--- a/springProject/src/main/java/com/teambind/springproject/common/config/RedisKeyspaceConfig.java
+++ b/springProject/src/main/java/com/teambind/springproject/common/config/RedisKeyspaceConfig.java
@@ -1,0 +1,42 @@
+package com.teambind.springproject.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/**
+ * Redis Keyspace Notification 설정 클래스.
+ * TTL 만료 이벤트를 수신하기 위한 리스너 컨테이너를 설정한다.
+ */
+@Configuration
+public class RedisKeyspaceConfig {
+
+  private static final String EXPIRED_EVENT_PATTERN = "__keyevent@*__:expired";
+
+  /**
+   * Redis 메시지 리스너 컨테이너 빈 설정.
+   *
+   * @param connectionFactory Redis 연결 팩토리
+   * @return RedisMessageListenerContainer 인스턴스
+   */
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      final RedisConnectionFactory connectionFactory
+  ) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    return container;
+  }
+
+  /**
+   * 만료 이벤트 패턴 토픽.
+   *
+   * @return PatternTopic 인스턴스
+   */
+  @Bean
+  public PatternTopic expiredEventTopic() {
+    return new PatternTopic(EXPIRED_EVENT_PATTERN);
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/event/SessionExpiredListener.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/event/SessionExpiredListener.java
@@ -1,0 +1,54 @@
+package com.teambind.springproject.domain.session.event;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis 키 만료 이벤트 리스너.
+ * 세션 키가 만료되면 SessionTimeoutEvent를 발행한다.
+ */
+@Component
+public class SessionExpiredListener implements MessageListener {
+
+  private static final Logger log = LoggerFactory.getLogger(SessionExpiredListener.class);
+  private static final String SESSION_KEY_PREFIX = "watch:session:";
+
+  private final ApplicationEventPublisher eventPublisher;
+
+  /**
+   * 생성자.
+   *
+   * @param listenerContainer Redis 메시지 리스너 컨테이너
+   * @param expiredEventTopic 만료 이벤트 토픽
+   * @param eventPublisher Spring 이벤트 발행자
+   */
+  public SessionExpiredListener(
+      final RedisMessageListenerContainer listenerContainer,
+      final PatternTopic expiredEventTopic,
+      final ApplicationEventPublisher eventPublisher
+  ) {
+    this.eventPublisher = eventPublisher;
+    listenerContainer.addMessageListener(this, expiredEventTopic);
+  }
+
+  @Override
+  public void onMessage(final Message message, final byte[] pattern) {
+    String expiredKey = new String(message.getBody());
+
+    if (!expiredKey.startsWith(SESSION_KEY_PREFIX)) {
+      return;
+    }
+
+    SessionTimeoutEvent event = SessionTimeoutEvent.fromRedisKey(expiredKey);
+    if (event != null) {
+      log.info("세션 타임아웃 감지: sessionId={}", event.sessionId());
+      eventPublisher.publishEvent(event);
+    }
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/event/SessionTimeoutEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/event/SessionTimeoutEvent.java
@@ -1,0 +1,30 @@
+package com.teambind.springproject.domain.session.event;
+
+/**
+ * 세션 타임아웃 이벤트.
+ * Redis TTL 만료 시 발행된다.
+ */
+public record SessionTimeoutEvent(
+    Long sessionId
+) {
+
+  /**
+   * Redis 키에서 세션 ID를 추출하여 이벤트를 생성한다.
+   *
+   * @param redisKey Redis 키 (예: watch:session:123)
+   * @return SessionTimeoutEvent 또는 null (키 형식이 맞지 않는 경우)
+   */
+  public static SessionTimeoutEvent fromRedisKey(final String redisKey) {
+    if (redisKey == null || !redisKey.startsWith("watch:session:")) {
+      return null;
+    }
+
+    String sessionIdStr = redisKey.substring("watch:session:".length());
+    try {
+      Long sessionId = Long.parseLong(sessionIdStr);
+      return new SessionTimeoutEvent(sessionId);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/event/SessionTimeoutHandler.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/event/SessionTimeoutHandler.java
@@ -1,0 +1,97 @@
+package com.teambind.springproject.domain.session.event;
+
+import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import com.teambind.springproject.domain.progress.repository.StudentContentProgressRepository;
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import com.teambind.springproject.domain.session.repository.WatchSessionRepository;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 세션 타임아웃 이벤트 핸들러.
+ * 세션 만료 시 마지막 진행률을 DB에 저장한다.
+ */
+@Component
+public class SessionTimeoutHandler {
+
+  private static final Logger log = LoggerFactory.getLogger(SessionTimeoutHandler.class);
+
+  private final WatchSessionRepository sessionRepository;
+  private final StudentContentProgressRepository progressRepository;
+  private final int completionThreshold;
+
+  public SessionTimeoutHandler(
+      final WatchSessionRepository sessionRepository,
+      final StudentContentProgressRepository progressRepository,
+      @Value("${learning.completion-threshold:90}") final int completionThreshold
+  ) {
+    this.sessionRepository = sessionRepository;
+    this.progressRepository = progressRepository;
+    this.completionThreshold = completionThreshold;
+  }
+
+  /**
+   * 세션 타임아웃 이벤트를 처리한다.
+   *
+   * @param event 세션 타임아웃 이벤트
+   */
+  @Async
+  @EventListener
+  @Transactional
+  public void handleSessionTimeout(final SessionTimeoutEvent event) {
+    Long sessionId = event.sessionId();
+    log.info("세션 타임아웃 처리 시작: sessionId={}", sessionId);
+
+    // 백업에서 세션 정보 조회
+    Optional<WatchSession> backupSession = sessionRepository.findBackupById(sessionId);
+
+    if (backupSession.isEmpty()) {
+      log.warn("타임아웃된 세션의 백업을 찾을 수 없음: sessionId={}", sessionId);
+      return;
+    }
+
+    WatchSession session = backupSession.get();
+
+    // 이미 종료된 세션이면 무시 (REPLACED, TERMINATED 등)
+    if (!session.isActive()) {
+      log.debug("이미 종료된 세션 무시: sessionId={}, status={}", sessionId, session.getStatus());
+      sessionRepository.deleteBackup(sessionId);
+      return;
+    }
+
+    // 진행률 저장
+    saveProgressOnTimeout(session);
+
+    // 백업 삭제
+    sessionRepository.deleteBackup(sessionId);
+    sessionRepository.deleteActiveByUserId(session.getUserId());
+
+    log.info("세션 타임아웃 처리 완료: sessionId={}, userId={}, contentId={}",
+        sessionId, session.getUserId(), session.getContentId());
+  }
+
+  private void saveProgressOnTimeout(final WatchSession session) {
+    StudentContentProgress progress = progressRepository
+        .findByContentIdAndStudentId(session.getContentId(), session.getUserId())
+        .orElse(null);
+
+    if (progress == null) {
+      log.debug("저장할 진행 기록 없음: contentId={}, studentId={}",
+          session.getContentId(), session.getUserId());
+      return;
+    }
+
+    // 마지막 접근 시간 업데이트
+    progress.incrementAccessCount();
+    progressRepository.save(progress);
+
+    log.debug("타임아웃 시 진행률 저장: contentId={}, studentId={}, progress={}%",
+        session.getContentId(), session.getUserId(), progress.getProgressPercentage());
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/repository/RedisWatchSessionRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/repository/RedisWatchSessionRepository.java
@@ -13,8 +13,10 @@ import org.springframework.stereotype.Repository;
 public class RedisWatchSessionRepository implements WatchSessionRepository {
 
   private static final String SESSION_KEY_PREFIX = "watch:session:";
+  private static final String SESSION_BACKUP_KEY_PREFIX = "watch:session:backup:";
   private static final String USER_ACTIVE_SESSION_KEY_PREFIX = "watch:user:active:";
   private static final long DEFAULT_TTL_SECONDS = 30;
+  private static final long BACKUP_TTL_SECONDS = 60;
 
   private final RedisTemplate<String, Object> redisTemplate;
 
@@ -25,9 +27,13 @@ public class RedisWatchSessionRepository implements WatchSessionRepository {
   @Override
   public void save(final WatchSession session) {
     String sessionKey = getSessionKey(session.getSessionId());
+    String backupKey = getBackupKey(session.getSessionId());
     String userActiveKey = getUserActiveSessionKey(session.getUserId());
 
     redisTemplate.opsForValue().set(sessionKey, session, DEFAULT_TTL_SECONDS, TimeUnit.SECONDS);
+
+    // 타임아웃 처리를 위한 백업 저장 (TTL보다 긴 시간 동안 유지)
+    redisTemplate.opsForValue().set(backupKey, session, BACKUP_TTL_SECONDS, TimeUnit.SECONDS);
 
     if (session.isActive()) {
       redisTemplate.opsForValue().set(
@@ -78,8 +84,28 @@ public class RedisWatchSessionRepository implements WatchSessionRepository {
     redisTemplate.expire(key, ttlSeconds, TimeUnit.SECONDS);
   }
 
+  @Override
+  public Optional<WatchSession> findBackupById(final Long sessionId) {
+    String backupKey = getBackupKey(sessionId);
+    Object value = redisTemplate.opsForValue().get(backupKey);
+    if (value instanceof WatchSession) {
+      return Optional.of((WatchSession) value);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public void deleteBackup(final Long sessionId) {
+    String backupKey = getBackupKey(sessionId);
+    redisTemplate.delete(backupKey);
+  }
+
   private String getSessionKey(final Long sessionId) {
     return SESSION_KEY_PREFIX + sessionId;
+  }
+
+  private String getBackupKey(final Long sessionId) {
+    return SESSION_BACKUP_KEY_PREFIX + sessionId;
   }
 
   private String getUserActiveSessionKey(final Long userId) {

--- a/springProject/src/main/java/com/teambind/springproject/domain/session/repository/WatchSessionRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/session/repository/WatchSessionRepository.java
@@ -53,4 +53,20 @@ public interface WatchSessionRepository {
    * @param ttlSeconds TTL (초)
    */
   void refreshTtl(Long sessionId, long ttlSeconds);
+
+  /**
+   * 백업된 세션을 조회한다.
+   * TTL 만료 시 타임아웃 처리를 위해 사용된다.
+   *
+   * @param sessionId 세션 ID
+   * @return 백업된 세션 (Optional)
+   */
+  Optional<WatchSession> findBackupById(Long sessionId);
+
+  /**
+   * 백업된 세션을 삭제한다.
+   *
+   * @param sessionId 세션 ID
+   */
+  void deleteBackup(Long sessionId);
 }


### PR DESCRIPTION
## Summary
- Redis Keyspace Notification을 활용한 세션 TTL 만료 감지 구현
- 세션 만료 시 백업 데이터에서 마지막 진행률 저장
- 비동기 이벤트 처리로 성능 영향 최소화

## Changes
- `RedisKeyspaceConfig`: Redis 만료 이벤트 리스너 컨테이너 설정
- `SessionTimeoutEvent`: 세션 타임아웃 도메인 이벤트
- `SessionExpiredListener`: Redis 키 만료 감지 및 Spring 이벤트 발행
- `SessionTimeoutHandler`: 타임아웃 처리 및 진행률 저장
- `WatchSessionRepository`: 백업 조회/삭제 메서드 추가
- `RedisWatchSessionRepository`: 백업 저장 (TTL 60초) 구현
- `SpringProjectApplication`: @EnableAsync 추가

## Test plan
- [ ] Redis에 세션 저장 후 30초 경과 시 백업에서 데이터 조회 확인
- [ ] 타임아웃 시 StudentContentProgress의 accessCount 증가 확인
- [ ] 이미 종료된 세션(REPLACED 등)은 무시되는지 확인