### PR TITLE
#13 부정 시청 이벤트 수집 API 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/controller/WatchEventController.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/controller/WatchEventController.java
@@ -1,0 +1,74 @@
+package com.teambind.springproject.domain.watchevent.controller;
+
+import com.teambind.springproject.domain.watchevent.dto.WatchEventRequest;
+import com.teambind.springproject.domain.watchevent.dto.WatchEventResponse;
+import com.teambind.springproject.domain.watchevent.entity.WatchEventType;
+import com.teambind.springproject.domain.watchevent.service.WatchEventService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 시청 이벤트 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/watch-events")
+public class WatchEventController {
+
+  private final WatchEventService eventService;
+
+  public WatchEventController(final WatchEventService eventService) {
+    this.eventService = eventService;
+  }
+
+  /**
+   * 시청 이벤트를 기록한다.
+   *
+   * @param request 이벤트 요청
+   * @return 저장된 이벤트 응답
+   */
+  @PostMapping
+  public ResponseEntity<WatchEventResponse> recordEvent(
+      @Valid @RequestBody final WatchEventRequest request
+  ) {
+    WatchEventResponse response = eventService.recordEvent(request);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 세션의 모든 이벤트를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 이벤트 목록
+   */
+  @GetMapping("/session/{sessionId}")
+  public ResponseEntity<List<WatchEventResponse>> getEventsBySession(
+      @PathVariable final Long sessionId
+  ) {
+    List<WatchEventResponse> events = eventService.getEventsBySession(sessionId);
+    return ResponseEntity.ok(events);
+  }
+
+  /**
+   * 세션의 특정 타입 이벤트를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @param type 이벤트 타입
+   * @return 이벤트 목록
+   */
+  @GetMapping("/session/{sessionId}/type")
+  public ResponseEntity<List<WatchEventResponse>> getEventsBySessionAndType(
+      @PathVariable final Long sessionId,
+      @RequestParam final WatchEventType type
+  ) {
+    List<WatchEventResponse> events = eventService.getEventsBySessionAndType(sessionId, type);
+    return ResponseEntity.ok(events);
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/dto/WatchEventRequest.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/dto/WatchEventRequest.java
@@ -1,0 +1,34 @@
+package com.teambind.springproject.domain.watchevent.dto;
+
+import com.teambind.springproject.domain.watchevent.entity.WatchEventType;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+/**
+ * 시청 이벤트 요청 DTO.
+ */
+public record WatchEventRequest(
+    @NotNull(message = "세션 ID는 필수입니다.")
+    Long sessionId,
+
+    @NotNull(message = "이벤트 타입은 필수입니다.")
+    WatchEventType eventType,
+
+    @NotNull(message = "이벤트 발생 시간은 필수입니다.")
+    LocalDateTime timestamp,
+
+    WatchEventPayload payload
+) {
+
+  /**
+   * 이벤트 페이로드.
+   * 이벤트 타입에 따라 필요한 필드가 다르다.
+   */
+  public record WatchEventPayload(
+      Integer positionSeconds,
+      Integer fromPosition,
+      Integer toPosition,
+      Double rate
+  ) {
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/dto/WatchEventResponse.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/dto/WatchEventResponse.java
@@ -1,0 +1,45 @@
+package com.teambind.springproject.domain.watchevent.dto;
+
+import com.teambind.springproject.domain.watchevent.entity.WatchEvent;
+import com.teambind.springproject.domain.watchevent.entity.WatchEventType;
+import java.time.LocalDateTime;
+
+/**
+ * 시청 이벤트 응답 DTO.
+ */
+public record WatchEventResponse(
+    Long id,
+    Long sessionId,
+    Long userId,
+    Long contentId,
+    WatchEventType eventType,
+    LocalDateTime eventTimestamp,
+    Integer positionSeconds,
+    Integer fromPositionSeconds,
+    Integer toPositionSeconds,
+    Double playbackRate,
+    LocalDateTime createdAt
+) {
+
+  /**
+   * WatchEvent 엔티티로부터 응답 DTO를 생성한다.
+   *
+   * @param event 시청 이벤트
+   * @return WatchEventResponse
+   */
+  public static WatchEventResponse from(final WatchEvent event) {
+    return new WatchEventResponse(
+        event.getId(),
+        event.getSessionId(),
+        event.getUserId(),
+        event.getContentId(),
+        event.getEventType(),
+        event.getEventTimestamp(),
+        event.getPositionSeconds(),
+        event.getFromPositionSeconds(),
+        event.getToPositionSeconds(),
+        event.getPlaybackRate(),
+        event.getCreatedAt()
+    );
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/entity/WatchEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/entity/WatchEvent.java
@@ -1,0 +1,232 @@
+package com.teambind.springproject.domain.watchevent.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * 시청 이벤트 엔티티.
+ * 클라이언트에서 발생하는 모든 시청 관련 이벤트를 기록한다.
+ */
+@Entity
+@Table(
+    name = "watch_event",
+    indexes = {
+        @Index(name = "idx_watch_event_session", columnList = "session_id"),
+        @Index(name = "idx_watch_event_user", columnList = "user_id"),
+        @Index(name = "idx_watch_event_content", columnList = "content_id"),
+        @Index(name = "idx_watch_event_type", columnList = "event_type"),
+        @Index(name = "idx_watch_event_timestamp", columnList = "event_timestamp")
+    }
+)
+public class WatchEvent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false)
+  private Long sessionId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "content_id", nullable = false)
+  private Long contentId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "event_type", nullable = false, length = 30)
+  private WatchEventType eventType;
+
+  @Column(name = "event_timestamp", nullable = false)
+  private LocalDateTime eventTimestamp;
+
+  @Column(name = "position_seconds")
+  private Integer positionSeconds;
+
+  @Column(name = "from_position_seconds")
+  private Integer fromPositionSeconds;
+
+  @Column(name = "to_position_seconds")
+  private Integer toPositionSeconds;
+
+  @Column(name = "playback_rate")
+  private Double playbackRate;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  protected WatchEvent() {
+  }
+
+  private WatchEvent(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final WatchEventType eventType,
+      final LocalDateTime eventTimestamp,
+      final Integer positionSeconds,
+      final Integer fromPositionSeconds,
+      final Integer toPositionSeconds,
+      final Double playbackRate
+  ) {
+    this.sessionId = sessionId;
+    this.userId = userId;
+    this.contentId = contentId;
+    this.eventType = eventType;
+    this.eventTimestamp = eventTimestamp;
+    this.positionSeconds = positionSeconds;
+    this.fromPositionSeconds = fromPositionSeconds;
+    this.toPositionSeconds = toPositionSeconds;
+    this.playbackRate = playbackRate;
+    this.createdAt = LocalDateTime.now();
+  }
+
+  /**
+   * 재생/일시정지 이벤트를 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param eventType 이벤트 타입 (PLAY, PAUSE)
+   * @param eventTimestamp 이벤트 발생 시간
+   * @param positionSeconds 현재 재생 위치
+   * @return WatchEvent 인스턴스
+   */
+  public static WatchEvent createPlaybackEvent(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final WatchEventType eventType,
+      final LocalDateTime eventTimestamp,
+      final Integer positionSeconds
+  ) {
+    return new WatchEvent(
+        sessionId, userId, contentId, eventType, eventTimestamp,
+        positionSeconds, null, null, null
+    );
+  }
+
+  /**
+   * 구간 이동(SEEK) 이벤트를 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param eventTimestamp 이벤트 발생 시간
+   * @param fromPositionSeconds 이동 전 위치
+   * @param toPositionSeconds 이동 후 위치
+   * @return WatchEvent 인스턴스
+   */
+  public static WatchEvent createSeekEvent(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final LocalDateTime eventTimestamp,
+      final Integer fromPositionSeconds,
+      final Integer toPositionSeconds
+  ) {
+    return new WatchEvent(
+        sessionId, userId, contentId, WatchEventType.SEEK, eventTimestamp,
+        null, fromPositionSeconds, toPositionSeconds, null
+    );
+  }
+
+  /**
+   * 재생 속도 변경 이벤트를 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param eventTimestamp 이벤트 발생 시간
+   * @param playbackRate 변경된 재생 속도
+   * @return WatchEvent 인스턴스
+   */
+  public static WatchEvent createRateChangeEvent(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final LocalDateTime eventTimestamp,
+      final Double playbackRate
+  ) {
+    return new WatchEvent(
+        sessionId, userId, contentId, WatchEventType.RATE_CHANGE, eventTimestamp,
+        null, null, null, playbackRate
+    );
+  }
+
+  /**
+   * 가시성 변경 이벤트를 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param eventType 이벤트 타입 (VISIBILITY_HIDDEN, VISIBILITY_VISIBLE)
+   * @param eventTimestamp 이벤트 발생 시간
+   * @return WatchEvent 인스턴스
+   */
+  public static WatchEvent createVisibilityEvent(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final WatchEventType eventType,
+      final LocalDateTime eventTimestamp
+  ) {
+    return new WatchEvent(
+        sessionId, userId, contentId, eventType, eventTimestamp,
+        null, null, null, null
+    );
+  }
+
+  // Getters
+  public Long getId() {
+    return id;
+  }
+
+  public Long getSessionId() {
+    return sessionId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public WatchEventType getEventType() {
+    return eventType;
+  }
+
+  public LocalDateTime getEventTimestamp() {
+    return eventTimestamp;
+  }
+
+  public Integer getPositionSeconds() {
+    return positionSeconds;
+  }
+
+  public Integer getFromPositionSeconds() {
+    return fromPositionSeconds;
+  }
+
+  public Integer getToPositionSeconds() {
+    return toPositionSeconds;
+  }
+
+  public Double getPlaybackRate() {
+    return playbackRate;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/entity/WatchEventType.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/entity/WatchEventType.java
@@ -1,0 +1,37 @@
+package com.teambind.springproject.domain.watchevent.entity;
+
+/**
+ * 시청 이벤트 타입.
+ */
+public enum WatchEventType {
+
+  /**
+   * 재생 시작.
+   */
+  PLAY,
+
+  /**
+   * 일시 정지.
+   */
+  PAUSE,
+
+  /**
+   * 위치 이동 (구간 건너뛰기).
+   */
+  SEEK,
+
+  /**
+   * 재생 속도 변경.
+   */
+  RATE_CHANGE,
+
+  /**
+   * 브라우저 탭 숨김 (비활성화).
+   */
+  VISIBILITY_HIDDEN,
+
+  /**
+   * 브라우저 탭 표시 (활성화).
+   */
+  VISIBILITY_VISIBLE
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/repository/WatchEventRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/repository/WatchEventRepository.java
@@ -1,0 +1,55 @@
+package com.teambind.springproject.domain.watchevent.repository;
+
+import com.teambind.springproject.domain.watchevent.entity.WatchEvent;
+import com.teambind.springproject.domain.watchevent.entity.WatchEventType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 시청 이벤트 Repository.
+ */
+@Repository
+public interface WatchEventRepository extends JpaRepository<WatchEvent, Long> {
+
+  /**
+   * 세션 ID로 이벤트를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 이벤트 목록
+   */
+  List<WatchEvent> findBySessionId(Long sessionId);
+
+  /**
+   * 사용자 ID와 콘텐츠 ID로 이벤트를 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 이벤트 목록
+   */
+  List<WatchEvent> findByUserIdAndContentId(Long userId, Long contentId);
+
+  /**
+   * 세션 ID와 이벤트 타입으로 이벤트를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @param eventType 이벤트 타입
+   * @return 이벤트 목록
+   */
+  List<WatchEvent> findBySessionIdAndEventType(Long sessionId, WatchEventType eventType);
+
+  /**
+   * 특정 기간 내 사용자의 이벤트를 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param startTime 시작 시간
+   * @param endTime 종료 시간
+   * @return 이벤트 목록
+   */
+  List<WatchEvent> findByUserIdAndEventTimestampBetween(
+      Long userId,
+      LocalDateTime startTime,
+      LocalDateTime endTime
+  );
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/service/WatchEventService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/service/WatchEventService.java
@@ -1,0 +1,147 @@
+package com.teambind.springproject.domain.watchevent.service;
+
+import com.teambind.springproject.domain.session.entity.WatchSession;
+import com.teambind.springproject.domain.session.repository.WatchSessionRepository;
+import com.teambind.springproject.domain.watchevent.dto.WatchEventRequest;
+import com.teambind.springproject.domain.watchevent.dto.WatchEventRequest.WatchEventPayload;
+import com.teambind.springproject.domain.watchevent.dto.WatchEventResponse;
+import com.teambind.springproject.domain.watchevent.entity.WatchEvent;
+import com.teambind.springproject.domain.watchevent.entity.WatchEventType;
+import com.teambind.springproject.domain.watchevent.repository.WatchEventRepository;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 시청 이벤트 서비스.
+ */
+@Service
+public class WatchEventService {
+
+  private static final Logger log = LoggerFactory.getLogger(WatchEventService.class);
+
+  private final WatchEventRepository eventRepository;
+  private final WatchSessionRepository sessionRepository;
+
+  public WatchEventService(
+      final WatchEventRepository eventRepository,
+      final WatchSessionRepository sessionRepository
+  ) {
+    this.eventRepository = eventRepository;
+    this.sessionRepository = sessionRepository;
+  }
+
+  /**
+   * 시청 이벤트를 기록한다.
+   *
+   * @param request 이벤트 요청
+   * @return 저장된 이벤트 응답
+   */
+  @Transactional
+  public WatchEventResponse recordEvent(final WatchEventRequest request) {
+    // 세션 검증
+    WatchSession session = validateAndGetSession(request.sessionId());
+
+    // 이벤트 생성
+    WatchEvent event = createEventFromRequest(request, session);
+
+    // 저장
+    WatchEvent savedEvent = eventRepository.save(event);
+
+    log.debug("시청 이벤트 기록: sessionId={}, type={}, userId={}, contentId={}",
+        request.sessionId(), request.eventType(), session.getUserId(), session.getContentId());
+
+    return WatchEventResponse.from(savedEvent);
+  }
+
+  /**
+   * 세션의 모든 이벤트를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 이벤트 목록
+   */
+  @Transactional(readOnly = true)
+  public List<WatchEventResponse> getEventsBySession(final Long sessionId) {
+    return eventRepository.findBySessionId(sessionId)
+        .stream()
+        .map(WatchEventResponse::from)
+        .toList();
+  }
+
+  /**
+   * 세션의 특정 타입 이벤트를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @param eventType 이벤트 타입
+   * @return 이벤트 목록
+   */
+  @Transactional(readOnly = true)
+  public List<WatchEventResponse> getEventsBySessionAndType(
+      final Long sessionId,
+      final WatchEventType eventType
+  ) {
+    return eventRepository.findBySessionIdAndEventType(sessionId, eventType)
+        .stream()
+        .map(WatchEventResponse::from)
+        .toList();
+  }
+
+  private WatchSession validateAndGetSession(final Long sessionId) {
+    Optional<WatchSession> sessionOpt = sessionRepository.findById(sessionId);
+
+    if (sessionOpt.isEmpty()) {
+      // 백업에서 조회 시도
+      sessionOpt = sessionRepository.findBackupById(sessionId);
+    }
+
+    if (sessionOpt.isEmpty()) {
+      throw new IllegalArgumentException("세션을 찾을 수 없습니다: " + sessionId);
+    }
+
+    return sessionOpt.get();
+  }
+
+  private WatchEvent createEventFromRequest(
+      final WatchEventRequest request,
+      final WatchSession session
+  ) {
+    WatchEventType eventType = request.eventType();
+    WatchEventPayload payload = request.payload();
+
+    return switch (eventType) {
+      case PLAY, PAUSE -> WatchEvent.createPlaybackEvent(
+          request.sessionId(),
+          session.getUserId(),
+          session.getContentId(),
+          eventType,
+          request.timestamp(),
+          payload != null ? payload.positionSeconds() : null
+      );
+      case SEEK -> WatchEvent.createSeekEvent(
+          request.sessionId(),
+          session.getUserId(),
+          session.getContentId(),
+          request.timestamp(),
+          payload != null ? payload.fromPosition() : null,
+          payload != null ? payload.toPosition() : null
+      );
+      case RATE_CHANGE -> WatchEvent.createRateChangeEvent(
+          request.sessionId(),
+          session.getUserId(),
+          session.getContentId(),
+          request.timestamp(),
+          payload != null ? payload.rate() : null
+      );
+      case VISIBILITY_HIDDEN, VISIBILITY_VISIBLE -> WatchEvent.createVisibilityEvent(
+          request.sessionId(),
+          session.getUserId(),
+          session.getContentId(),
+          eventType,
+          request.timestamp()
+      );
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- 시청 이벤트(PLAY, PAUSE, SEEK, RATE_CHANGE, VISIBILITY_HIDDEN, VISIBILITY_VISIBLE) 수집 API 구현
- 이벤트 타입별 팩토리 메서드로 타입 안전성 확보
- 세션 검증 후 이벤트 저장

## API Endpoints
- `POST /api/v1/watch-events` - 이벤트 기록
- `GET /api/v1/watch-events/session/{sessionId}` - 세션 이벤트 조회
- `GET /api/v1/watch-events/session/{sessionId}/type?type={type}` - 타입별 이벤트 조회

## Request Example
```json
{
  "sessionId": 123456789,
  "eventType": "SEEK",
  "timestamp": "2025-01-01T12:00:00",
  "payload": {
    "fromPosition": 100,
    "toPosition": 300
  }
}
```

## Changes
- `WatchEventType`: 이벤트 타입 enum
- `WatchEvent`: 이벤트 엔티티 (JPA)
- `WatchEventRepository`: 조회 메서드
- `WatchEventRequest/Response`: DTO
- `WatchEventService`: 비즈니스 로직
- `WatchEventController`: REST API

## Test plan
- [ ] PLAY/PAUSE 이벤트 기록 확인
- [ ] SEEK 이벤트에서 fromPosition, toPosition 저장 확인
- [ ] RATE_CHANGE 이벤트에서 playbackRate 저장 확인
- [ ] VISIBILITY 이벤트 기록 확인
- [ ] 잘못된 세션 ID로 요청 시 에러 응답 확인