### PR TITLE
#14 부정 시청 판정 로직 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/fraud/entity/FraudRecord.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/fraud/entity/FraudRecord.java
@@ -1,0 +1,196 @@
+package com.teambind.springproject.domain.fraud.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * 부정 시청 기록 엔티티.
+ */
+@Entity
+@Table(
+    name = "fraud_record",
+    indexes = {
+        @Index(name = "idx_fraud_session", columnList = "session_id"),
+        @Index(name = "idx_fraud_user_content", columnList = "user_id, content_id"),
+        @Index(name = "idx_fraud_type", columnList = "fraud_type")
+    }
+)
+public class FraudRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false)
+  private Long sessionId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "content_id", nullable = false)
+  private Long contentId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "fraud_type", nullable = false, length = 30)
+  private FraudType fraudType;
+
+  @Column(name = "start_seconds")
+  private Integer startSeconds;
+
+  @Column(name = "end_seconds")
+  private Integer endSeconds;
+
+  @Column(name = "detail", length = 500)
+  private String detail;
+
+  @Column(name = "detected_at", nullable = false)
+  private LocalDateTime detectedAt;
+
+  protected FraudRecord() {
+  }
+
+  private FraudRecord(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final FraudType fraudType,
+      final Integer startSeconds,
+      final Integer endSeconds,
+      final String detail
+  ) {
+    this.sessionId = sessionId;
+    this.userId = userId;
+    this.contentId = contentId;
+    this.fraudType = fraudType;
+    this.startSeconds = startSeconds;
+    this.endSeconds = endSeconds;
+    this.detail = detail;
+    this.detectedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 배속 재생 부정 기록을 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param playbackRate 재생 속도
+   * @return FraudRecord 인스턴스
+   */
+  public static FraudRecord fastPlayback(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Double playbackRate
+  ) {
+    return new FraudRecord(
+        sessionId, userId, contentId, FraudType.FAST_PLAYBACK,
+        null, null, "재생 속도: " + playbackRate + "x"
+    );
+  }
+
+  /**
+   * 탭 숨김 부정 기록을 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param startSeconds 숨김 시작 위치
+   * @param endSeconds 숨김 종료 위치
+   * @return FraudRecord 인스턴스
+   */
+  public static FraudRecord tabHidden(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Integer startSeconds,
+      final Integer endSeconds
+  ) {
+    int duration = endSeconds - startSeconds;
+    return new FraudRecord(
+        sessionId, userId, contentId, FraudType.TAB_HIDDEN,
+        startSeconds, endSeconds, "탭 숨김 " + duration + "초"
+    );
+  }
+
+  /**
+   * 구간 스킵 부정 기록을 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param fromSeconds 스킵 시작 위치
+   * @param toSeconds 스킵 종료 위치
+   * @return FraudRecord 인스턴스
+   */
+  public static FraudRecord skipSegment(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Integer fromSeconds,
+      final Integer toSeconds
+  ) {
+    int skipped = toSeconds - fromSeconds;
+    return new FraudRecord(
+        sessionId, userId, contentId, FraudType.SKIP_SEGMENT,
+        fromSeconds, toSeconds, "스킵 " + skipped + "초"
+    );
+  }
+
+  /**
+   * 부정 구간의 길이를 반환한다.
+   *
+   * @return 구간 길이(초), 구간이 없으면 0
+   */
+  public int getDuration() {
+    if (startSeconds == null || endSeconds == null) {
+      return 0;
+    }
+    return endSeconds - startSeconds;
+  }
+
+  // Getters
+  public Long getId() {
+    return id;
+  }
+
+  public Long getSessionId() {
+    return sessionId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public FraudType getFraudType() {
+    return fraudType;
+  }
+
+  public Integer getStartSeconds() {
+    return startSeconds;
+  }
+
+  public Integer getEndSeconds() {
+    return endSeconds;
+  }
+
+  public String getDetail() {
+    return detail;
+  }
+
+  public LocalDateTime getDetectedAt() {
+    return detectedAt;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/fraud/entity/FraudType.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/fraud/entity/FraudType.java
@@ -1,0 +1,27 @@
+package com.teambind.springproject.domain.fraud.entity;
+
+/**
+ * 부정 시청 유형.
+ */
+public enum FraudType {
+
+  /**
+   * 배속 재생 (1.0 초과).
+   */
+  FAST_PLAYBACK,
+
+  /**
+   * 탭 전환 (브라우저 비활성화).
+   */
+  TAB_HIDDEN,
+
+  /**
+   * 구간 스킵 (5초 초과).
+   */
+  SKIP_SEGMENT,
+
+  /**
+   * 동시 시청 (다른 세션).
+   */
+  CONCURRENT_SESSION
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/fraud/entity/WatchedSegment.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/fraud/entity/WatchedSegment.java
@@ -1,0 +1,175 @@
+package com.teambind.springproject.domain.fraud.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * 시청 구간 엔티티.
+ * 사용자가 실제로 시청한 구간을 기록한다.
+ */
+@Entity
+@Table(
+    name = "watched_segment",
+    indexes = {
+        @Index(name = "idx_segment_session", columnList = "session_id"),
+        @Index(name = "idx_segment_user_content", columnList = "user_id, content_id")
+    }
+)
+public class WatchedSegment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "session_id", nullable = false)
+  private Long sessionId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "content_id", nullable = false)
+  private Long contentId;
+
+  @Column(name = "start_seconds", nullable = false)
+  private Integer startSeconds;
+
+  @Column(name = "end_seconds", nullable = false)
+  private Integer endSeconds;
+
+  @Column(name = "is_valid", nullable = false)
+  private Boolean isValid = true;
+
+  @Column(name = "playback_rate")
+  private Double playbackRate = 1.0;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  protected WatchedSegment() {
+  }
+
+  private WatchedSegment(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Integer startSeconds,
+      final Integer endSeconds,
+      final Boolean isValid,
+      final Double playbackRate
+  ) {
+    this.sessionId = sessionId;
+    this.userId = userId;
+    this.contentId = contentId;
+    this.startSeconds = startSeconds;
+    this.endSeconds = endSeconds;
+    this.isValid = isValid;
+    this.playbackRate = playbackRate;
+    this.createdAt = LocalDateTime.now();
+  }
+
+  /**
+   * 유효한 시청 구간을 생성한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param startSeconds 시작 시간(초)
+   * @param endSeconds 종료 시간(초)
+   * @param playbackRate 재생 속도
+   * @return WatchedSegment 인스턴스
+   */
+  public static WatchedSegment createValid(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Integer startSeconds,
+      final Integer endSeconds,
+      final Double playbackRate
+  ) {
+    boolean isValid = playbackRate == null || playbackRate <= 1.0;
+    return new WatchedSegment(
+        sessionId, userId, contentId, startSeconds, endSeconds, isValid, playbackRate
+    );
+  }
+
+  /**
+   * 무효한 시청 구간을 생성한다. (스킵, 탭 전환 등)
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param startSeconds 시작 시간(초)
+   * @param endSeconds 종료 시간(초)
+   * @return WatchedSegment 인스턴스
+   */
+  public static WatchedSegment createInvalid(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Integer startSeconds,
+      final Integer endSeconds
+  ) {
+    return new WatchedSegment(
+        sessionId, userId, contentId, startSeconds, endSeconds, false, null
+    );
+  }
+
+  /**
+   * 구간의 길이를 반환한다.
+   *
+   * @return 구간 길이(초)
+   */
+  public int getDuration() {
+    return endSeconds - startSeconds;
+  }
+
+  /**
+   * 구간을 무효화한다.
+   */
+  public void invalidate() {
+    this.isValid = false;
+  }
+
+  // Getters
+  public Long getId() {
+    return id;
+  }
+
+  public Long getSessionId() {
+    return sessionId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public Long getContentId() {
+    return contentId;
+  }
+
+  public Integer getStartSeconds() {
+    return startSeconds;
+  }
+
+  public Integer getEndSeconds() {
+    return endSeconds;
+  }
+
+  public Boolean getIsValid() {
+    return isValid;
+  }
+
+  public Double getPlaybackRate() {
+    return playbackRate;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/fraud/repository/FraudRecordRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/fraud/repository/FraudRecordRepository.java
@@ -1,0 +1,53 @@
+package com.teambind.springproject.domain.fraud.repository;
+
+import com.teambind.springproject.domain.fraud.entity.FraudRecord;
+import com.teambind.springproject.domain.fraud.entity.FraudType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 부정 시청 기록 Repository.
+ */
+@Repository
+public interface FraudRecordRepository extends JpaRepository<FraudRecord, Long> {
+
+  /**
+   * 세션의 부정 기록을 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 부정 기록 목록
+   */
+  List<FraudRecord> findBySessionId(Long sessionId);
+
+  /**
+   * 사용자의 콘텐츠별 부정 기록을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 부정 기록 목록
+   */
+  List<FraudRecord> findByUserIdAndContentId(Long userId, Long contentId);
+
+  /**
+   * 사용자의 콘텐츠별 특정 유형 부정 기록을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param fraudType 부정 유형
+   * @return 부정 기록 목록
+   */
+  List<FraudRecord> findByUserIdAndContentIdAndFraudType(
+      Long userId,
+      Long contentId,
+      FraudType fraudType
+  );
+
+  /**
+   * 세션의 부정 기록 수를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 부정 기록 수
+   */
+  long countBySessionId(Long sessionId);
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/fraud/repository/WatchedSegmentRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/fraud/repository/WatchedSegmentRepository.java
@@ -1,0 +1,47 @@
+package com.teambind.springproject.domain.fraud.repository;
+
+import com.teambind.springproject.domain.fraud.entity.WatchedSegment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 시청 구간 Repository.
+ */
+@Repository
+public interface WatchedSegmentRepository extends JpaRepository<WatchedSegment, Long> {
+
+  /**
+   * 세션의 모든 시청 구간을 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 시청 구간 목록
+   */
+  List<WatchedSegment> findBySessionId(Long sessionId);
+
+  /**
+   * 사용자의 콘텐츠별 유효한 시청 구간을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 유효한 시청 구간 목록
+   */
+  List<WatchedSegment> findByUserIdAndContentIdAndIsValidTrue(Long userId, Long contentId);
+
+  /**
+   * 사용자의 콘텐츠별 총 유효 시청 시간을 계산한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 총 유효 시청 시간(초)
+   */
+  @Query("SELECT COALESCE(SUM(s.endSeconds - s.startSeconds), 0) "
+      + "FROM WatchedSegment s "
+      + "WHERE s.userId = :userId AND s.contentId = :contentId AND s.isValid = true")
+  Integer sumValidWatchedSeconds(
+      @Param("userId") Long userId,
+      @Param("contentId") Long contentId
+  );
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/fraud/service/FraudDetectionService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/fraud/service/FraudDetectionService.java
@@ -1,0 +1,186 @@
+package com.teambind.springproject.domain.fraud.service;
+
+import com.teambind.springproject.domain.fraud.entity.FraudRecord;
+import com.teambind.springproject.domain.fraud.entity.WatchedSegment;
+import com.teambind.springproject.domain.fraud.repository.FraudRecordRepository;
+import com.teambind.springproject.domain.fraud.repository.WatchedSegmentRepository;
+import com.teambind.springproject.domain.watchevent.entity.WatchEvent;
+import com.teambind.springproject.domain.watchevent.entity.WatchEventType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 부정 시청 감지 서비스.
+ */
+@Service
+public class FraudDetectionService {
+
+  private static final Logger log = LoggerFactory.getLogger(FraudDetectionService.class);
+
+  private final FraudRecordRepository fraudRepository;
+  private final WatchedSegmentRepository segmentRepository;
+  private final int skipAllowanceSeconds;
+
+  public FraudDetectionService(
+      final FraudRecordRepository fraudRepository,
+      final WatchedSegmentRepository segmentRepository,
+      @Value("${fraud.skip-allowance-seconds:5}") final int skipAllowanceSeconds
+  ) {
+    this.fraudRepository = fraudRepository;
+    this.segmentRepository = segmentRepository;
+    this.skipAllowanceSeconds = skipAllowanceSeconds;
+  }
+
+  /**
+   * 이벤트를 분석하여 부정 시청을 감지한다.
+   *
+   * @param event 시청 이벤트
+   */
+  @Transactional
+  public void analyzeEvent(final WatchEvent event) {
+    switch (event.getEventType()) {
+      case SEEK -> handleSeekEvent(event);
+      case RATE_CHANGE -> handleRateChangeEvent(event);
+      case VISIBILITY_HIDDEN -> handleVisibilityHiddenEvent(event);
+      case PLAY -> handlePlayEvent(event);
+      default -> {
+        // PAUSE, VISIBILITY_VISIBLE 등은 별도 처리 없음
+      }
+    }
+  }
+
+  /**
+   * 시청 구간을 기록한다.
+   *
+   * @param sessionId 세션 ID
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param startSeconds 시작 시간
+   * @param endSeconds 종료 시간
+   * @param playbackRate 재생 속도
+   */
+  @Transactional
+  public void recordWatchedSegment(
+      final Long sessionId,
+      final Long userId,
+      final Long contentId,
+      final Integer startSeconds,
+      final Integer endSeconds,
+      final Double playbackRate
+  ) {
+    if (startSeconds == null || endSeconds == null || startSeconds >= endSeconds) {
+      return;
+    }
+
+    WatchedSegment segment = WatchedSegment.createValid(
+        sessionId, userId, contentId, startSeconds, endSeconds, playbackRate
+    );
+    segmentRepository.save(segment);
+
+    log.debug("시청 구간 기록: sessionId={}, {}초~{}초, rate={}, valid={}",
+        sessionId, startSeconds, endSeconds, playbackRate, segment.getIsValid());
+  }
+
+  /**
+   * 사용자의 콘텐츠별 유효 시청 시간을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 유효 시청 시간(초)
+   */
+  @Transactional(readOnly = true)
+  public int getValidWatchedSeconds(final Long userId, final Long contentId) {
+    return segmentRepository.sumValidWatchedSeconds(userId, contentId);
+  }
+
+  /**
+   * 세션의 부정 기록 수를 조회한다.
+   *
+   * @param sessionId 세션 ID
+   * @return 부정 기록 수
+   */
+  @Transactional(readOnly = true)
+  public long getFraudCount(final Long sessionId) {
+    return fraudRepository.countBySessionId(sessionId);
+  }
+
+  private void handleSeekEvent(final WatchEvent event) {
+    Integer from = event.getFromPositionSeconds();
+    Integer to = event.getToPositionSeconds();
+
+    if (from == null || to == null) {
+      return;
+    }
+
+    int skipped = to - from;
+
+    // 5초 이내 스킵은 허용
+    if (skipped <= skipAllowanceSeconds) {
+      log.debug("허용된 스킵: {}초 -> {}초 ({}초)", from, to, skipped);
+      return;
+    }
+
+    // 뒤로 이동(되감기)은 부정 아님
+    if (skipped < 0) {
+      return;
+    }
+
+    // 스킵 구간 부정 기록
+    FraudRecord fraud = FraudRecord.skipSegment(
+        event.getSessionId(),
+        event.getUserId(),
+        event.getContentId(),
+        from,
+        to
+    );
+    fraudRepository.save(fraud);
+
+    // 스킵 구간은 무효 시청으로 기록
+    WatchedSegment invalidSegment = WatchedSegment.createInvalid(
+        event.getSessionId(),
+        event.getUserId(),
+        event.getContentId(),
+        from,
+        to
+    );
+    segmentRepository.save(invalidSegment);
+
+    log.info("스킵 감지: sessionId={}, {}초 -> {}초 ({}초 스킵)",
+        event.getSessionId(), from, to, skipped);
+  }
+
+  private void handleRateChangeEvent(final WatchEvent event) {
+    Double rate = event.getPlaybackRate();
+
+    if (rate == null || rate <= 1.0) {
+      return;
+    }
+
+    // 배속 재생 부정 기록
+    FraudRecord fraud = FraudRecord.fastPlayback(
+        event.getSessionId(),
+        event.getUserId(),
+        event.getContentId(),
+        rate
+    );
+    fraudRepository.save(fraud);
+
+    log.info("배속 재생 감지: sessionId={}, rate={}x", event.getSessionId(), rate);
+  }
+
+  private void handleVisibilityHiddenEvent(final WatchEvent event) {
+    // VISIBILITY_HIDDEN 이벤트 발생 시점 기록
+    // 실제 무효 처리는 VISIBILITY_VISIBLE 이벤트 시 구간으로 계산
+    log.debug("탭 숨김 감지: sessionId={}, position={}",
+        event.getSessionId(), event.getPositionSeconds());
+  }
+
+  private void handlePlayEvent(final WatchEvent event) {
+    // PLAY 이벤트는 시청 시작 지점 기록용
+    log.debug("재생 시작: sessionId={}, position={}",
+        event.getSessionId(), event.getPositionSeconds());
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/watchevent/service/WatchEventService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/watchevent/service/WatchEventService.java
@@ -1,5 +1,6 @@
 package com.teambind.springproject.domain.watchevent.service;
 
+import com.teambind.springproject.domain.fraud.service.FraudDetectionService;
 import com.teambind.springproject.domain.session.entity.WatchSession;
 import com.teambind.springproject.domain.session.repository.WatchSessionRepository;
 import com.teambind.springproject.domain.watchevent.dto.WatchEventRequest;
@@ -25,13 +26,16 @@ public class WatchEventService {
 
   private final WatchEventRepository eventRepository;
   private final WatchSessionRepository sessionRepository;
+  private final FraudDetectionService fraudDetectionService;
 
   public WatchEventService(
       final WatchEventRepository eventRepository,
-      final WatchSessionRepository sessionRepository
+      final WatchSessionRepository sessionRepository,
+      final FraudDetectionService fraudDetectionService
   ) {
     this.eventRepository = eventRepository;
     this.sessionRepository = sessionRepository;
+    this.fraudDetectionService = fraudDetectionService;
   }
 
   /**
@@ -50,6 +54,9 @@ public class WatchEventService {
 
     // 저장
     WatchEvent savedEvent = eventRepository.save(event);
+
+    // 부정 시청 감지
+    fraudDetectionService.analyzeEvent(savedEvent);
 
     log.debug("시청 이벤트 기록: sessionId={}, type={}, userId={}, contentId={}",
         request.sessionId(), request.eventType(), session.getUserId(), session.getContentId());


### PR DESCRIPTION
## Summary
- 부정 시청 감지 로직 구현 (배속, 탭 전환, 스킵)
- 시청 구간 및 부정 기록 저장
- 이벤트 발생 시 자동 분석

## 부정 시청 유형
- `FAST_PLAYBACK`: 배속 재생 (rate > 1.0)
- `TAB_HIDDEN`: 탭 전환 (브라우저 비활성화)
- `SKIP_SEGMENT`: 구간 스킵 (5초 초과)
- `CONCURRENT_SESSION`: 동시 시청 (예약)

## 정책
- 5초 이내 스킵: 허용 (설정 가능)
- 뒤로 감기: 부정 아님
- 배속 재생 구간: 무효 시청으로 처리

## Changes
- `WatchedSegment`: 시청 구간 엔티티
- `FraudType`: 부정 유형 enum
- `FraudRecord`: 부정 기록 엔티티
- `WatchedSegmentRepository`: 유효 시청 시간 계산
- `FraudRecordRepository`: 부정 기록 조회
- `FraudDetectionService`: 이벤트 분석 및 부정 감지
- `WatchEventService`: 부정 감지 서비스 연동

## Test plan
- [ ] SEEK 이벤트로 5초 초과 스킵 시 FraudRecord 생성 확인
- [ ] SEEK 이벤트로 5초 이내 스킵 시 허용 확인
- [ ] RATE_CHANGE 이벤트로 rate > 1.0 시 FraudRecord 생성 확인
- [ ] 유효 시청 시간 합계 계산 확인