### PR TITLE
#15 학습률 계산 로직 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/learning/service/LearningRateService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/learning/service/LearningRateService.java
@@ -1,0 +1,153 @@
+package com.teambind.springproject.domain.learning.service;
+
+import com.teambind.springproject.domain.fraud.repository.WatchedSegmentRepository;
+import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import com.teambind.springproject.domain.progress.repository.StudentContentProgressRepository;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 학습률 계산 서비스.
+ * 부정 시청을 제외한 실제 시청 시간 기반으로 학습률을 계산한다.
+ */
+@Service
+public class LearningRateService {
+
+  private static final Logger log = LoggerFactory.getLogger(LearningRateService.class);
+
+  private final WatchedSegmentRepository segmentRepository;
+  private final StudentContentProgressRepository progressRepository;
+  private final int completionThreshold;
+
+  public LearningRateService(
+      final WatchedSegmentRepository segmentRepository,
+      final StudentContentProgressRepository progressRepository,
+      @Value("${learning.completion-threshold:90}") final int completionThreshold
+  ) {
+    this.segmentRepository = segmentRepository;
+    this.progressRepository = progressRepository;
+    this.completionThreshold = completionThreshold;
+  }
+
+  /**
+   * 학습률을 계산하고 업데이트한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param totalDurationSeconds 전체 영상 길이(초)
+   * @return 계산된 학습률 (0-100)
+   */
+  @Transactional
+  public int calculateAndUpdateLearningRate(
+      final Long userId,
+      final Long contentId,
+      final Integer totalDurationSeconds
+  ) {
+    if (totalDurationSeconds == null || totalDurationSeconds <= 0) {
+      log.warn("유효하지 않은 영상 길이: userId={}, contentId={}, duration={}",
+          userId, contentId, totalDurationSeconds);
+      return 0;
+    }
+
+    // 유효 시청 시간 조회
+    int validWatchedSeconds = segmentRepository.sumValidWatchedSeconds(userId, contentId);
+
+    // 학습률 계산 (최대 100%)
+    int learningRate = Math.min(
+        (int) ((validWatchedSeconds * 100.0) / totalDurationSeconds),
+        100
+    );
+
+    // 진행 상황 업데이트
+    updateProgress(userId, contentId, learningRate, validWatchedSeconds);
+
+    log.debug("학습률 계산: userId={}, contentId={}, validSeconds={}, total={}, rate={}%",
+        userId, contentId, validWatchedSeconds, totalDurationSeconds, learningRate);
+
+    return learningRate;
+  }
+
+  /**
+   * 현재 학습률을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param totalDurationSeconds 전체 영상 길이(초)
+   * @return 학습률 (0-100)
+   */
+  @Transactional(readOnly = true)
+  public int getLearningRate(
+      final Long userId,
+      final Long contentId,
+      final Integer totalDurationSeconds
+  ) {
+    if (totalDurationSeconds == null || totalDurationSeconds <= 0) {
+      return 0;
+    }
+
+    int validWatchedSeconds = segmentRepository.sumValidWatchedSeconds(userId, contentId);
+    return Math.min(
+        (int) ((validWatchedSeconds * 100.0) / totalDurationSeconds),
+        100
+    );
+  }
+
+  /**
+   * 유효 시청 시간을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @return 유효 시청 시간(초)
+   */
+  @Transactional(readOnly = true)
+  public int getValidWatchedSeconds(final Long userId, final Long contentId) {
+    return segmentRepository.sumValidWatchedSeconds(userId, contentId);
+  }
+
+  /**
+   * 완료 여부를 확인한다.
+   *
+   * @param userId 사용자 ID
+   * @param contentId 콘텐츠 ID
+   * @param totalDurationSeconds 전체 영상 길이(초)
+   * @return 완료 여부
+   */
+  @Transactional(readOnly = true)
+  public boolean isCompleted(
+      final Long userId,
+      final Long contentId,
+      final Integer totalDurationSeconds
+  ) {
+    int learningRate = getLearningRate(userId, contentId, totalDurationSeconds);
+    return learningRate >= completionThreshold;
+  }
+
+  private void updateProgress(
+      final Long userId,
+      final Long contentId,
+      final int learningRate,
+      final int validWatchedSeconds
+  ) {
+    Optional<StudentContentProgress> progressOpt =
+        progressRepository.findByContentIdAndStudentId(contentId, userId);
+
+    if (progressOpt.isEmpty()) {
+      log.debug("진행 기록 없음: userId={}, contentId={}", userId, contentId);
+      return;
+    }
+
+    StudentContentProgress progress = progressOpt.get();
+
+    // 학습률 기반으로 진행률 업데이트
+    progress.updateLearningRate(learningRate, completionThreshold);
+
+    progressRepository.save(progress);
+
+    log.debug("진행 상황 업데이트: userId={}, contentId={}, rate={}%, completed={}",
+        userId, contentId, learningRate, progress.getIsCompleted());
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/entity/StudentContentProgress.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/entity/StudentContentProgress.java
@@ -127,6 +127,27 @@ public class StudentContentProgress {
     this.lastAccessedAt = LocalDateTime.now();
   }
 
+  /**
+   * 학습률 기반으로 진행률을 업데이트한다.
+   * 부정 시청을 제외한 유효 시청 시간 기반 학습률을 적용한다.
+   *
+   * @param learningRate 학습률 (0-100)
+   * @param completionThreshold 완료 기준 퍼센트
+   */
+  public void updateLearningRate(final int learningRate, final int completionThreshold) {
+    // 학습률이 기존 진행률보다 높을 때만 업데이트
+    if (learningRate > this.progressPercentage) {
+      this.progressPercentage = learningRate;
+    }
+    this.lastAccessedAt = LocalDateTime.now();
+
+    // 완료 처리
+    if (!this.isCompleted && this.progressPercentage >= completionThreshold) {
+      this.isCompleted = true;
+      this.completedAt = LocalDateTime.now();
+    }
+  }
+
   // Getters
   public Long getId() {
     return id;

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/service/ProgressService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/service/ProgressService.java
@@ -1,5 +1,6 @@
 package com.teambind.springproject.domain.progress.service;
 
+import com.teambind.springproject.domain.learning.service.LearningRateService;
 import com.teambind.springproject.domain.progress.dto.ProgressReportRequest;
 import com.teambind.springproject.domain.progress.dto.ProgressResponse;
 import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
@@ -19,17 +20,20 @@ public class ProgressService {
 
   private final StudentContentProgressRepository progressRepository;
   private final WatchSessionRepository sessionRepository;
+  private final LearningRateService learningRateService;
   private final int completionThreshold;
   private final long sessionTimeoutSeconds;
 
   public ProgressService(
       final StudentContentProgressRepository progressRepository,
       final WatchSessionRepository sessionRepository,
+      final LearningRateService learningRateService,
       @Value("${learning.completion-threshold:90}") final int completionThreshold,
       @Value("${watch.session.timeout-seconds:30}") final long sessionTimeoutSeconds
   ) {
     this.progressRepository = progressRepository;
     this.sessionRepository = sessionRepository;
+    this.learningRateService = learningRateService;
     this.completionThreshold = completionThreshold;
     this.sessionTimeoutSeconds = sessionTimeoutSeconds;
   }
@@ -69,7 +73,19 @@ public class ProgressService {
 
     progressRepository.save(progress);
 
-    return ProgressResponse.from(progress);
+    // 학습률 기반 진행률 업데이트 (부정 시청 제외)
+    learningRateService.calculateAndUpdateLearningRate(
+        session.getUserId(),
+        request.contentId(),
+        request.totalDurationSeconds()
+    );
+
+    // 업데이트된 진행 상황 다시 조회
+    StudentContentProgress updatedProgress = progressRepository
+        .findByContentIdAndStudentId(request.contentId(), session.getUserId())
+        .orElse(progress);
+
+    return ProgressResponse.from(updatedProgress);
   }
 
   /**


### PR DESCRIPTION
## Summary
- 부정 시청을 제외한 유효 시청 시간 기반 학습률 계산
- 90% 이상 시청 시 완료 처리 (설정 가능)
- 진행 상황 보고 시 자동으로 학습률 계산 및 업데이트

## 계산 공식
```
학습률 = (유효 시청 시간 / 전체 영상 길이) × 100
```

## 완료 조건
- `learning.completion-threshold` 설정값 이상 시청 시 완료 처리
- 기본값: 90%

## Changes
- `LearningRateService`: 학습률 계산 및 업데이트 서비스
- `StudentContentProgress.updateLearningRate()`: 학습률 기반 진행률 업데이트 메서드
- `ProgressService`: 진행 보고 시 학습률 계산 연동

## Test plan
- [ ] 유효 시청 시간 기반 학습률 계산 확인
- [ ] 부정 시청 구간 제외 확인
- [ ] 90% 이상 시청 시 is_completed=true 확인
- [ ] 진행률은 증가만 하고 감소하지 않는지 확인