### PR TITLE
#7 Chunked Upload API 구현

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/config/TusConfig.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/config/TusConfig.java
@@ -1,0 +1,37 @@
+package com.teambind.springproject.domain.upload.config;
+
+import me.desair.tus.server.TusFileUploadService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * TUS 프로토콜 기반 업로드 설정.
+ */
+@Configuration
+public class TusConfig {
+
+  @Value("${video.upload.temp-path:/tmp/video-temp}")
+  private String tempPath;
+
+  @Value("${video.upload.chunk-size:5242880}")
+  private Long chunkSize;
+
+  @Value("${video.upload.max-file-size:10737418240}")
+  private Long maxFileSize;
+
+  /**
+   * TUS 파일 업로드 서비스 빈 설정.
+   *
+   * @return TusFileUploadService 인스턴스
+   */
+  @Bean
+  public TusFileUploadService tusFileUploadService() {
+    return new TusFileUploadService()
+        .withStoragePath(tempPath)
+        .withDownloadFeature()
+        .withUploadExpirationPeriod(24 * 60 * 60 * 1000L)  // 24시간
+        .withMaxUploadSize(maxFileSize)
+        .withThreadLocalCache(true);
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/controller/TusUploadController.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/controller/TusUploadController.java
@@ -1,0 +1,122 @@
+package com.teambind.springproject.domain.upload.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import me.desair.tus.server.TusFileUploadService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * TUS 프로토콜 기반 청크 업로드 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/videos/upload")
+@CrossOrigin(
+    exposedHeaders = {
+        "Location", "Upload-Offset", "Upload-Length",
+        "Tus-Version", "Tus-Resumable", "Tus-Max-Size", "Tus-Extension"
+    }
+)
+public class TusUploadController {
+
+  private static final Logger log = LoggerFactory.getLogger(TusUploadController.class);
+
+  private final TusFileUploadService tusService;
+
+  public TusUploadController(final TusFileUploadService tusService) {
+    this.tusService = tusService;
+  }
+
+  /**
+   * TUS OPTIONS 요청 처리.
+   * 클라이언트가 서버의 TUS 지원 여부와 확장 기능을 확인한다.
+   *
+   * @param request HTTP 요청
+   * @param response HTTP 응답
+   */
+  @RequestMapping(method = RequestMethod.OPTIONS)
+  public void processOptions(
+      final HttpServletRequest request,
+      final HttpServletResponse response
+  ) throws IOException {
+    tusService.process(request, response);
+    log.debug("TUS OPTIONS 요청 처리");
+  }
+
+  /**
+   * TUS POST 요청 처리.
+   * 새로운 업로드를 생성한다.
+   *
+   * @param request HTTP 요청
+   * @param response HTTP 응답
+   * @param uploadLength 업로드 파일 크기
+   */
+  @PostMapping
+  public void processPost(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      @RequestHeader(value = "Upload-Length", required = false) final Long uploadLength
+  ) throws IOException {
+    tusService.process(request, response);
+    log.info("TUS POST 요청 처리: Upload-Length={}", uploadLength);
+  }
+
+  /**
+   * TUS HEAD 요청 처리.
+   * 업로드 상태를 조회한다.
+   *
+   * @param request HTTP 요청
+   * @param response HTTP 응답
+   */
+  @RequestMapping(value = "/**", method = RequestMethod.HEAD)
+  public void processHead(
+      final HttpServletRequest request,
+      final HttpServletResponse response
+  ) throws IOException {
+    tusService.process(request, response);
+    log.debug("TUS HEAD 요청 처리: {}", request.getRequestURI());
+  }
+
+  /**
+   * TUS PATCH 요청 처리.
+   * 청크 데이터를 업로드한다.
+   *
+   * @param request HTTP 요청
+   * @param response HTTP 응답
+   * @param uploadOffset 현재 업로드 오프셋
+   */
+  @PatchMapping("/**")
+  public void processPatch(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      @RequestHeader(value = "Upload-Offset", required = false) final Long uploadOffset
+  ) throws IOException {
+    tusService.process(request, response);
+    log.debug("TUS PATCH 요청 처리: Upload-Offset={}", uploadOffset);
+  }
+
+  /**
+   * TUS DELETE 요청 처리.
+   * 업로드를 취소한다.
+   *
+   * @param request HTTP 요청
+   * @param response HTTP 응답
+   */
+  @DeleteMapping("/**")
+  public void processDelete(
+      final HttpServletRequest request,
+      final HttpServletResponse response
+  ) throws IOException {
+    tusService.process(request, response);
+    log.info("TUS DELETE 요청 처리: {}", request.getRequestURI());
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/entity/UploadStatus.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/entity/UploadStatus.java
@@ -1,0 +1,32 @@
+package com.teambind.springproject.domain.upload.entity;
+
+/**
+ * 업로드 상태.
+ */
+public enum UploadStatus {
+
+  /**
+   * 업로드 진행 중.
+   */
+  IN_PROGRESS,
+
+  /**
+   * 업로드 완료.
+   */
+  COMPLETED,
+
+  /**
+   * 업로드 취소.
+   */
+  CANCELLED,
+
+  /**
+   * 업로드 실패.
+   */
+  FAILED,
+
+  /**
+   * 업로드 만료.
+   */
+  EXPIRED
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/entity/VideoUpload.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/entity/VideoUpload.java
@@ -1,0 +1,215 @@
+package com.teambind.springproject.domain.upload.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * 비디오 업로드 엔티티.
+ */
+@Entity
+@Table(
+    name = "video_upload",
+    indexes = {
+        @Index(name = "idx_upload_user", columnList = "user_id"),
+        @Index(name = "idx_upload_status", columnList = "status"),
+        @Index(name = "idx_upload_tus_id", columnList = "tus_upload_id")
+    }
+)
+public class VideoUpload {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "tus_upload_id", nullable = false, unique = true)
+  private String tusUploadId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "original_filename", nullable = false)
+  private String originalFilename;
+
+  @Column(name = "file_size", nullable = false)
+  private Long fileSize;
+
+  @Column(name = "uploaded_bytes", nullable = false)
+  private Long uploadedBytes = 0L;
+
+  @Column(name = "content_type")
+  private String contentType;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  private UploadStatus status = UploadStatus.IN_PROGRESS;
+
+  @Column(name = "storage_path")
+  private String storagePath;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
+  @Column(name = "completed_at")
+  private LocalDateTime completedAt;
+
+  protected VideoUpload() {
+  }
+
+  private VideoUpload(
+      final String tusUploadId,
+      final Long userId,
+      final String originalFilename,
+      final Long fileSize,
+      final String contentType
+  ) {
+    this.tusUploadId = tusUploadId;
+    this.userId = userId;
+    this.originalFilename = originalFilename;
+    this.fileSize = fileSize;
+    this.contentType = contentType;
+    this.uploadedBytes = 0L;
+    this.status = UploadStatus.IN_PROGRESS;
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 새로운 업로드를 생성한다.
+   *
+   * @param tusUploadId TUS 업로드 ID
+   * @param userId 사용자 ID
+   * @param originalFilename 원본 파일명
+   * @param fileSize 파일 크기
+   * @param contentType 콘텐츠 타입
+   * @return VideoUpload 인스턴스
+   */
+  public static VideoUpload create(
+      final String tusUploadId,
+      final Long userId,
+      final String originalFilename,
+      final Long fileSize,
+      final String contentType
+  ) {
+    return new VideoUpload(tusUploadId, userId, originalFilename, fileSize, contentType);
+  }
+
+  /**
+   * 업로드 진행 상황을 업데이트한다.
+   *
+   * @param uploadedBytes 업로드된 바이트 수
+   */
+  public void updateProgress(final Long uploadedBytes) {
+    this.uploadedBytes = uploadedBytes;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 업로드를 완료 처리한다.
+   *
+   * @param storagePath 저장 경로
+   */
+  public void complete(final String storagePath) {
+    this.status = UploadStatus.COMPLETED;
+    this.storagePath = storagePath;
+    this.uploadedBytes = this.fileSize;
+    this.completedAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 업로드를 취소한다.
+   */
+  public void cancel() {
+    this.status = UploadStatus.CANCELLED;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 업로드를 실패 처리한다.
+   */
+  public void fail() {
+    this.status = UploadStatus.FAILED;
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  /**
+   * 업로드 진행률을 계산한다.
+   *
+   * @return 진행률 (0-100)
+   */
+  public int getProgressPercentage() {
+    if (fileSize == 0) {
+      return 0;
+    }
+    return (int) ((uploadedBytes * 100) / fileSize);
+  }
+
+  /**
+   * 업로드가 진행 중인지 확인한다.
+   *
+   * @return 진행 중이면 true
+   */
+  public boolean isInProgress() {
+    return status == UploadStatus.IN_PROGRESS;
+  }
+
+  // Getters
+  public Long getId() {
+    return id;
+  }
+
+  public String getTusUploadId() {
+    return tusUploadId;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public String getOriginalFilename() {
+    return originalFilename;
+  }
+
+  public Long getFileSize() {
+    return fileSize;
+  }
+
+  public Long getUploadedBytes() {
+    return uploadedBytes;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public UploadStatus getStatus() {
+    return status;
+  }
+
+  public String getStoragePath() {
+    return storagePath;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+
+  public LocalDateTime getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public LocalDateTime getCompletedAt() {
+    return completedAt;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/repository/VideoUploadRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/repository/VideoUploadRepository.java
@@ -1,0 +1,40 @@
+package com.teambind.springproject.domain.upload.repository;
+
+import com.teambind.springproject.domain.upload.entity.UploadStatus;
+import com.teambind.springproject.domain.upload.entity.VideoUpload;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 비디오 업로드 Repository.
+ */
+@Repository
+public interface VideoUploadRepository extends JpaRepository<VideoUpload, Long> {
+
+  /**
+   * TUS 업로드 ID로 조회한다.
+   *
+   * @param tusUploadId TUS 업로드 ID
+   * @return VideoUpload (Optional)
+   */
+  Optional<VideoUpload> findByTusUploadId(String tusUploadId);
+
+  /**
+   * 사용자의 업로드 목록을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @return 업로드 목록
+   */
+  List<VideoUpload> findByUserId(Long userId);
+
+  /**
+   * 사용자의 특정 상태 업로드 목록을 조회한다.
+   *
+   * @param userId 사용자 ID
+   * @param status 상태
+   * @return 업로드 목록
+   */
+  List<VideoUpload> findByUserIdAndStatus(Long userId, UploadStatus status);
+}


### PR DESCRIPTION
## Summary
- TUS 프로토콜 기반 청크 업로드 API 구현
- tus-java-server 라이브러리 사용
- 대용량 파일 업로드 지원 (최대 10GB)

## TUS Protocol Endpoints
- `OPTIONS /api/v1/videos/upload` - 서버 기능 확인
- `POST /api/v1/videos/upload` - 업로드 생성
- `HEAD /api/v1/videos/upload/{id}` - 업로드 상태 조회
- `PATCH /api/v1/videos/upload/{id}` - 청크 업로드
- `DELETE /api/v1/videos/upload/{id}` - 업로드 취소

## Configuration
- `video.upload.temp-path`: 임시 저장 경로
- `video.upload.chunk-size`: 청크 크기 (기본 5MB)
- `video.upload.max-file-size`: 최대 파일 크기 (기본 10GB)

## Changes
- `TusConfig`: TusFileUploadService 빈 설정
- `UploadStatus`: 업로드 상태 enum
- `VideoUpload`: 업로드 메타데이터 엔티티
- `VideoUploadRepository`: JPA 레포지토리
- `TusUploadController`: TUS 프로토콜 엔드포인트

## Test plan
- [ ] OPTIONS 요청으로 TUS 지원 확인
- [ ] POST로 업로드 생성 후 Location 헤더 확인
- [ ] PATCH로 청크 업로드 후 Upload-Offset 확인
- [ ] HEAD로 업로드 상태 조회 확인
- [ ] DELETE로 업로드 취소 확인