### PR TITLE
#8 업로드 완료 처리 및 LMS 연동

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/SpringProjectApplication.java
+++ b/springProject/src/main/java/com/teambind/springproject/SpringProjectApplication.java
@@ -4,6 +4,7 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Video Service Application.
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
  */
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class SpringProjectApplication {
 
   /**

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/config/WebMvcConfig.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/config/WebMvcConfig.java
@@ -1,0 +1,25 @@
+package com.teambind.springproject.domain.upload.config;
+
+import com.teambind.springproject.domain.upload.event.TusUploadEventListener;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web MVC 설정.
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+  private final TusUploadEventListener tusUploadEventListener;
+
+  public WebMvcConfig(final TusUploadEventListener tusUploadEventListener) {
+    this.tusUploadEventListener = tusUploadEventListener;
+  }
+
+  @Override
+  public void addInterceptors(final InterceptorRegistry registry) {
+    registry.addInterceptor(tusUploadEventListener)
+        .addPathPatterns("/api/v1/videos/upload/**");
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/event/TusUploadEventListener.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/event/TusUploadEventListener.java
@@ -1,0 +1,86 @@
+package com.teambind.springproject.domain.upload.event;
+
+import com.teambind.springproject.domain.upload.service.UploadCompletionService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import me.desair.tus.server.TusFileUploadService;
+import me.desair.tus.server.upload.UploadInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * TUS 업로드 이벤트 인터셉터.
+ * 업로드 완료 시 자동으로 파일을 최종 저장소로 이동한다.
+ */
+@Component
+public class TusUploadEventListener implements HandlerInterceptor {
+
+  private static final Logger log = LoggerFactory.getLogger(TusUploadEventListener.class);
+
+  private final TusFileUploadService tusService;
+  private final UploadCompletionService completionService;
+
+  public TusUploadEventListener(
+      final TusFileUploadService tusService,
+      final UploadCompletionService completionService
+  ) {
+    this.tusService = tusService;
+    this.completionService = completionService;
+  }
+
+  @Override
+  public void afterCompletion(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Object handler,
+      final Exception ex
+  ) {
+    String method = request.getMethod();
+    String uri = request.getRequestURI();
+
+    if (!uri.startsWith("/api/v1/videos/upload")) {
+      return;
+    }
+
+    try {
+      if ("PATCH".equals(method)) {
+        handlePatchCompletion(uri, response);
+      }
+    } catch (Exception e) {
+      log.error("업로드 이벤트 처리 실패: {}", e.getMessage(), e);
+    }
+  }
+
+  private void handlePatchCompletion(final String uri, final HttpServletResponse response)
+      throws Exception {
+    // 응답 성공 시에만 처리
+    if (response.getStatus() != 204) {
+      return;
+    }
+
+    UploadInfo uploadInfo = tusService.getUploadInfo(uri);
+
+    if (uploadInfo == null) {
+      return;
+    }
+
+    // 업로드 완료 여부 확인
+    if (!uploadInfo.isUploadInProgress()
+        && uploadInfo.getOffset().equals(uploadInfo.getLength())) {
+      log.info("업로드 완료 감지: uri={}, size={}", uri, uploadInfo.getLength());
+
+      try {
+        String storagePath = completionService.completeUpload(uri);
+        log.info("파일 저장 완료: {}", storagePath);
+      } catch (Exception e) {
+        log.error("업로드 완료 처리 실패: {}", e.getMessage(), e);
+      }
+    } else {
+      // 진행 상황 업데이트
+      completionService.updateUploadProgress(uri);
+    }
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/scheduler/UploadCleanupScheduler.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/scheduler/UploadCleanupScheduler.java
@@ -1,0 +1,40 @@
+package com.teambind.springproject.domain.upload.scheduler;
+
+import java.io.IOException;
+import me.desair.tus.server.TusFileUploadService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 업로드 임시 파일 정리 스케줄러.
+ * 만료된 업로드 임시 파일을 주기적으로 정리한다.
+ */
+@Component
+public class UploadCleanupScheduler {
+
+  private static final Logger log = LoggerFactory.getLogger(UploadCleanupScheduler.class);
+
+  private final TusFileUploadService tusService;
+
+  public UploadCleanupScheduler(final TusFileUploadService tusService) {
+    this.tusService = tusService;
+  }
+
+  /**
+   * 만료된 업로드를 정리한다.
+   * 매일 새벽 3시에 실행.
+   */
+  @Scheduled(cron = "0 0 3 * * *")
+  public void cleanupExpiredUploads() {
+    log.info("만료된 업로드 정리 시작");
+
+    try {
+      tusService.cleanup();
+      log.info("만료된 업로드 정리 완료");
+    } catch (IOException e) {
+      log.error("업로드 정리 실패: {}", e.getMessage(), e);
+    }
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/service/UploadCompletionService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/service/UploadCompletionService.java
@@ -1,0 +1,174 @@
+package com.teambind.springproject.domain.upload.service;
+
+import com.teambind.springproject.domain.upload.entity.VideoUpload;
+import com.teambind.springproject.domain.upload.repository.VideoUploadRepository;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import me.desair.tus.server.TusFileUploadService;
+import me.desair.tus.server.upload.UploadInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 업로드 완료 처리 서비스.
+ */
+@Service
+public class UploadCompletionService {
+
+  private static final Logger log = LoggerFactory.getLogger(UploadCompletionService.class);
+
+  private final TusFileUploadService tusService;
+  private final VideoUploadRepository uploadRepository;
+  private final String storagePath;
+
+  public UploadCompletionService(
+      final TusFileUploadService tusService,
+      final VideoUploadRepository uploadRepository,
+      @Value("${video.upload.storage-path:/tmp/video-uploads}") final String storagePath
+  ) {
+    this.tusService = tusService;
+    this.uploadRepository = uploadRepository;
+    this.storagePath = storagePath;
+  }
+
+  /**
+   * 업로드 완료를 처리한다.
+   *
+   * @param uploadUri TUS 업로드 URI
+   * @return 저장된 파일 경로
+   */
+  @Transactional
+  public String completeUpload(final String uploadUri) throws Exception {
+    UploadInfo uploadInfo = tusService.getUploadInfo(uploadUri);
+
+    if (uploadInfo == null) {
+      throw new IllegalArgumentException("업로드 정보를 찾을 수 없습니다: " + uploadUri);
+    }
+
+    if (!uploadInfo.isUploadInProgress() && uploadInfo.getOffset().equals(uploadInfo.getLength())) {
+      // 업로드 완료됨 - 파일 이동
+      String finalPath = moveToStorage(uploadUri, uploadInfo);
+
+      // DB 업데이트
+      String tusUploadId = extractUploadId(uploadUri);
+      updateUploadRecord(tusUploadId, finalPath);
+
+      // TUS 임시 파일 정리
+      tusService.deleteUpload(uploadUri);
+
+      log.info("업로드 완료: uploadUri={}, storagePath={}", uploadUri, finalPath);
+      return finalPath;
+    }
+
+    throw new IllegalStateException("업로드가 아직 완료되지 않았습니다.");
+  }
+
+  /**
+   * 업로드 메타데이터를 저장한다.
+   *
+   * @param uploadUri TUS 업로드 URI
+   * @param userId 사용자 ID
+   */
+  @Transactional
+  public void saveUploadMetadata(final String uploadUri, final Long userId) throws Exception {
+    UploadInfo uploadInfo = tusService.getUploadInfo(uploadUri);
+
+    if (uploadInfo == null) {
+      throw new IllegalArgumentException("업로드 정보를 찾을 수 없습니다: " + uploadUri);
+    }
+
+    String tusUploadId = extractUploadId(uploadUri);
+    String filename = uploadInfo.getFileName();
+    if (filename == null || filename.isEmpty()) {
+      filename = "unknown";
+    }
+
+    VideoUpload upload = VideoUpload.create(
+        tusUploadId,
+        userId,
+        filename,
+        uploadInfo.getLength(),
+        uploadInfo.getFileMimeType()
+    );
+
+    uploadRepository.save(upload);
+    log.debug("업로드 메타데이터 저장: tusUploadId={}, filename={}", tusUploadId, filename);
+  }
+
+  /**
+   * 업로드 진행 상황을 업데이트한다.
+   *
+   * @param uploadUri TUS 업로드 URI
+   */
+  @Transactional
+  public void updateUploadProgress(final String uploadUri) throws Exception {
+    UploadInfo uploadInfo = tusService.getUploadInfo(uploadUri);
+
+    if (uploadInfo == null) {
+      return;
+    }
+
+    String tusUploadId = extractUploadId(uploadUri);
+    uploadRepository.findByTusUploadId(tusUploadId)
+        .ifPresent(upload -> {
+          upload.updateProgress(uploadInfo.getOffset());
+          uploadRepository.save(upload);
+        });
+  }
+
+  private String moveToStorage(final String uploadUri, final UploadInfo uploadInfo)
+      throws Exception {
+    // 저장 디렉토리 생성
+    Path storageDir = Paths.get(storagePath);
+    Files.createDirectories(storageDir);
+
+    // UUID 기반 파일명 생성
+    String originalFilename = uploadInfo.getFileName();
+    String extension = getFileExtension(originalFilename);
+    String newFilename = UUID.randomUUID().toString() + extension;
+    Path targetPath = storageDir.resolve(newFilename);
+
+    // 파일 복사
+    try (InputStream inputStream = tusService.getUploadedBytes(uploadUri)) {
+      Files.copy(inputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    return targetPath.toString();
+  }
+
+  private void updateUploadRecord(final String tusUploadId, final String storagePath) {
+    uploadRepository.findByTusUploadId(tusUploadId)
+        .ifPresent(upload -> {
+          upload.complete(storagePath);
+          uploadRepository.save(upload);
+        });
+  }
+
+  private String extractUploadId(final String uploadUri) {
+    // /api/v1/videos/upload/xxx 에서 xxx 추출
+    int lastSlash = uploadUri.lastIndexOf('/');
+    if (lastSlash >= 0 && lastSlash < uploadUri.length() - 1) {
+      return uploadUri.substring(lastSlash + 1);
+    }
+    return uploadUri;
+  }
+
+  private String getFileExtension(final String filename) {
+    if (filename == null || filename.isEmpty()) {
+      return "";
+    }
+    int dotIndex = filename.lastIndexOf('.');
+    if (dotIndex >= 0) {
+      return filename.substring(dotIndex);
+    }
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary
- 업로드 완료 시 임시 파일 → 최종 저장소 자동 이동
- UUID 기반 파일명 생성으로 충돌 방지
- 만료된 업로드 임시 파일 정리 스케줄러

## 기능
- **UploadCompletionService**: 업로드 완료 처리 및 파일 이동
- **TusUploadEventListener**: PATCH 완료 시 자동 완료 처리
- **UploadCleanupScheduler**: 매일 새벽 3시 만료 업로드 정리

## 파일 저장 흐름
1. 청크 업로드 완료 (TUS PATCH)
2. TusUploadEventListener가 완료 감지
3. UploadCompletionService가 임시 → 최종 경로로 이동
4. VideoUpload 레코드 업데이트 (status=COMPLETED)
5. TUS 임시 파일 정리

## Configuration
- `video.upload.storage-path`: 최종 저장 경로
- `video.upload.temp-path`: TUS 임시 경로

## Changes
- `UploadCompletionService`: 완료 처리 및 파일 이동
- `TusUploadEventListener`: 업로드 완료 이벤트 감지
- `WebMvcConfig`: 인터셉터 등록
- `UploadCleanupScheduler`: 임시 파일 정리
- `SpringProjectApplication`: @EnableScheduling 추가

## Test plan
- [ ] 청크 업로드 완료 시 파일 자동 이동 확인
- [ ] UUID 기반 파일명 생성 확인
- [ ] VideoUpload 상태 COMPLETED 업데이트 확인
- [ ] 만료 업로드 정리 확인