### PR TITLE
동영상 업로드 시 week_contents 연동

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/content/entity/ContentType.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/content/entity/ContentType.java
@@ -1,0 +1,10 @@
+package com.teambind.springproject.domain.content.entity;
+
+/**
+ * 콘텐츠 유형.
+ */
+public enum ContentType {
+  VIDEO,
+  DOCUMENT,
+  LINK
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/content/entity/WeekContent.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/content/entity/WeekContent.java
@@ -1,0 +1,161 @@
+package com.teambind.springproject.domain.content.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * 주차별 콘텐츠 엔티티.
+ */
+@Entity
+@Table(
+    name = "week_contents",
+    indexes = {
+        @Index(name = "idx_week_contents_week", columnList = "week_id"),
+        @Index(name = "idx_week_contents_order", columnList = "display_order")
+    }
+)
+public class WeekContent {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "week_id", nullable = false)
+  private Long weekId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "content_type", nullable = false, length = 20)
+  private ContentType contentType;
+
+  @Column(name = "title", nullable = false, length = 200)
+  private String title;
+
+  @Column(name = "content_url", nullable = false, length = 500)
+  private String contentUrl;
+
+  @Column(name = "duration", length = 10)
+  private String duration;
+
+  @Column(name = "display_order", nullable = false)
+  private Integer displayOrder;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  protected WeekContent() {
+  }
+
+  private WeekContent(
+      final Long weekId,
+      final ContentType contentType,
+      final String title,
+      final String contentUrl,
+      final String duration,
+      final Integer displayOrder
+  ) {
+    this.weekId = weekId;
+    this.contentType = contentType;
+    this.title = title;
+    this.contentUrl = contentUrl;
+    this.duration = duration;
+    this.displayOrder = displayOrder;
+    this.createdAt = LocalDateTime.now();
+  }
+
+  /**
+   * 비디오 콘텐츠를 생성한다.
+   *
+   * @param weekId 주차 ID
+   * @param title 콘텐츠 제목
+   * @param contentUrl 콘텐츠 URL
+   * @param duration 동영상 길이 (예: "45:23")
+   * @param displayOrder 표시 순서
+   * @return WeekContent 인스턴스
+   */
+  public static WeekContent createVideo(
+      final Long weekId,
+      final String title,
+      final String contentUrl,
+      final String duration,
+      final Integer displayOrder
+  ) {
+    return new WeekContent(weekId, ContentType.VIDEO, title, contentUrl, duration, displayOrder);
+  }
+
+  /**
+   * 문서 콘텐츠를 생성한다.
+   *
+   * @param weekId 주차 ID
+   * @param title 콘텐츠 제목
+   * @param contentUrl 콘텐츠 URL
+   * @param displayOrder 표시 순서
+   * @return WeekContent 인스턴스
+   */
+  public static WeekContent createDocument(
+      final Long weekId,
+      final String title,
+      final String contentUrl,
+      final Integer displayOrder
+  ) {
+    return new WeekContent(weekId, ContentType.DOCUMENT, title, contentUrl, null, displayOrder);
+  }
+
+  /**
+   * 링크 콘텐츠를 생성한다.
+   *
+   * @param weekId 주차 ID
+   * @param title 콘텐츠 제목
+   * @param contentUrl 콘텐츠 URL
+   * @param displayOrder 표시 순서
+   * @return WeekContent 인스턴스
+   */
+  public static WeekContent createLink(
+      final Long weekId,
+      final String title,
+      final String contentUrl,
+      final Integer displayOrder
+  ) {
+    return new WeekContent(weekId, ContentType.LINK, title, contentUrl, null, displayOrder);
+  }
+
+  // Getters
+  public Long getId() {
+    return id;
+  }
+
+  public Long getWeekId() {
+    return weekId;
+  }
+
+  public ContentType getContentType() {
+    return contentType;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getContentUrl() {
+    return contentUrl;
+  }
+
+  public String getDuration() {
+    return duration;
+  }
+
+  public Integer getDisplayOrder() {
+    return displayOrder;
+  }
+
+  public LocalDateTime getCreatedAt() {
+    return createdAt;
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/content/repository/WeekContentRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/content/repository/WeekContentRepository.java
@@ -1,0 +1,30 @@
+package com.teambind.springproject.domain.content.repository;
+
+import com.teambind.springproject.domain.content.entity.WeekContent;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 주차별 콘텐츠 리포지토리.
+ */
+public interface WeekContentRepository extends JpaRepository<WeekContent, Long> {
+
+  /**
+   * 주차별 최대 표시 순서를 조회한다.
+   *
+   * @param weekId 주차 ID
+   * @return 최대 표시 순서
+   */
+  @Query("SELECT COALESCE(MAX(wc.displayOrder), 0) FROM WeekContent wc WHERE wc.weekId = :weekId")
+  Integer findMaxDisplayOrderByWeekId(@Param("weekId") Long weekId);
+
+  /**
+   * 콘텐츠 URL로 콘텐츠를 조회한다.
+   *
+   * @param contentUrl 콘텐츠 URL
+   * @return WeekContent
+   */
+  Optional<WeekContent> findByContentUrl(String contentUrl);
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/stream/controller/VideoStreamController.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/stream/controller/VideoStreamController.java
@@ -1,0 +1,181 @@
+package com.teambind.springproject.domain.stream.controller;
+
+import com.teambind.springproject.domain.upload.entity.UploadStatus;
+import com.teambind.springproject.domain.upload.entity.VideoUpload;
+import com.teambind.springproject.domain.upload.repository.VideoUploadRepository;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+/**
+ * 비디오 스트리밍 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/videos/stream")
+public class VideoStreamController {
+
+  private static final Logger log = LoggerFactory.getLogger(VideoStreamController.class);
+  private static final int BUFFER_SIZE = 8192;
+
+  private final VideoUploadRepository uploadRepository;
+
+  public VideoStreamController(final VideoUploadRepository uploadRepository) {
+    this.uploadRepository = uploadRepository;
+  }
+
+  /**
+   * 비디오를 스트리밍한다.
+   *
+   * @param videoId 비디오 업로드 ID
+   * @param rangeHeader Range 헤더
+   * @return 비디오 스트림
+   */
+  @GetMapping("/{videoId}")
+  public ResponseEntity<StreamingResponseBody> streamVideo(
+      @PathVariable final Long videoId,
+      @RequestHeader(value = HttpHeaders.RANGE, required = false) final String rangeHeader
+  ) {
+    VideoUpload upload = uploadRepository.findById(videoId)
+        .orElse(null);
+
+    if (upload == null) {
+      log.warn("비디오를 찾을 수 없음: videoId={}", videoId);
+      return ResponseEntity.notFound().build();
+    }
+
+    if (upload.getStatus() != UploadStatus.COMPLETED) {
+      log.warn("업로드가 완료되지 않음: videoId={}, status={}", videoId, upload.getStatus());
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    Path videoPath = Paths.get(upload.getStoragePath());
+    if (!Files.exists(videoPath)) {
+      log.error("비디오 파일이 존재하지 않음: path={}", upload.getStoragePath());
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    }
+
+    try {
+      long fileSize = Files.size(videoPath);
+      String contentType = upload.getContentType();
+      if (contentType == null || contentType.isEmpty()) {
+        contentType = "video/mp4";
+      }
+
+      if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
+        return handleRangeRequest(videoPath, rangeHeader, fileSize, contentType);
+      }
+
+      return handleFullRequest(videoPath, fileSize, contentType);
+
+    } catch (IOException e) {
+      log.error("비디오 스트리밍 실패: videoId={}, error={}", videoId, e.getMessage(), e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+  }
+
+  private ResponseEntity<StreamingResponseBody> handleFullRequest(
+      final Path videoPath,
+      final long fileSize,
+      final String contentType
+  ) {
+    StreamingResponseBody responseBody = outputStream -> {
+      try (InputStream inputStream = Files.newInputStream(videoPath)) {
+        copyStream(inputStream, outputStream, 0, fileSize);
+      }
+    };
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.parseMediaType(contentType));
+    headers.setContentLength(fileSize);
+    headers.set(HttpHeaders.ACCEPT_RANGES, "bytes");
+
+    return ResponseEntity.ok()
+        .headers(headers)
+        .body(responseBody);
+  }
+
+  private ResponseEntity<StreamingResponseBody> handleRangeRequest(
+      final Path videoPath,
+      final String rangeHeader,
+      final long fileSize,
+      final String contentType
+  ) {
+    // bytes=0-1024 형태 파싱
+    String range = rangeHeader.substring(6);
+    String[] ranges = range.split("-");
+
+    long rangeStart = Long.parseLong(ranges[0]);
+    long rangeEnd = ranges.length > 1 && !ranges[1].isEmpty()
+        ? Long.parseLong(ranges[1])
+        : fileSize - 1;
+
+    if (rangeEnd >= fileSize) {
+      rangeEnd = fileSize - 1;
+    }
+
+    long contentLength = rangeEnd - rangeStart + 1;
+    final long finalRangeStart = rangeStart;
+    final long finalRangeEnd = rangeEnd;
+
+    StreamingResponseBody responseBody = outputStream -> {
+      try (InputStream inputStream = Files.newInputStream(videoPath)) {
+        copyStream(inputStream, outputStream, finalRangeStart, contentLength);
+      }
+    };
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.parseMediaType(contentType));
+    headers.setContentLength(contentLength);
+    headers.set(HttpHeaders.ACCEPT_RANGES, "bytes");
+    headers.set(HttpHeaders.CONTENT_RANGE,
+        String.format("bytes %d-%d/%d", rangeStart, finalRangeEnd, fileSize));
+
+    return ResponseEntity.status(HttpStatus.PARTIAL_CONTENT)
+        .headers(headers)
+        .body(responseBody);
+  }
+
+  private void copyStream(
+      final InputStream inputStream,
+      final OutputStream outputStream,
+      final long skip,
+      final long length
+  ) throws IOException {
+    if (skip > 0) {
+      long skipped = inputStream.skip(skip);
+      if (skipped < skip) {
+        throw new IOException("스킵 실패: expected=" + skip + ", actual=" + skipped);
+      }
+    }
+
+    byte[] buffer = new byte[BUFFER_SIZE];
+    long remaining = length;
+
+    while (remaining > 0) {
+      int toRead = (int) Math.min(buffer.length, remaining);
+      int read = inputStream.read(buffer, 0, toRead);
+      if (read == -1) {
+        break;
+      }
+      outputStream.write(buffer, 0, read);
+      remaining -= read;
+    }
+
+    outputStream.flush();
+  }
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/entity/VideoUpload.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/entity/VideoUpload.java
@@ -54,6 +54,15 @@ public class VideoUpload {
   @Column(name = "storage_path")
   private String storagePath;
 
+  @Column(name = "week_id")
+  private Long weekId;
+
+  @Column(name = "title", length = 200)
+  private String title;
+
+  @Column(name = "duration", length = 10)
+  private String duration;
+
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 
@@ -71,13 +80,17 @@ public class VideoUpload {
       final Long userId,
       final String originalFilename,
       final Long fileSize,
-      final String contentType
+      final String contentType,
+      final Long weekId,
+      final String title
   ) {
     this.tusUploadId = tusUploadId;
     this.userId = userId;
     this.originalFilename = originalFilename;
     this.fileSize = fileSize;
     this.contentType = contentType;
+    this.weekId = weekId;
+    this.title = title;
     this.uploadedBytes = 0L;
     this.status = UploadStatus.IN_PROGRESS;
     this.createdAt = LocalDateTime.now();
@@ -92,6 +105,8 @@ public class VideoUpload {
    * @param originalFilename 원본 파일명
    * @param fileSize 파일 크기
    * @param contentType 콘텐츠 타입
+   * @param weekId 주차 ID
+   * @param title 콘텐츠 제목
    * @return VideoUpload 인스턴스
    */
   public static VideoUpload create(
@@ -99,9 +114,12 @@ public class VideoUpload {
       final Long userId,
       final String originalFilename,
       final Long fileSize,
-      final String contentType
+      final String contentType,
+      final Long weekId,
+      final String title
   ) {
-    return new VideoUpload(tusUploadId, userId, originalFilename, fileSize, contentType);
+    return new VideoUpload(tusUploadId, userId, originalFilename, fileSize, contentType,
+        weekId, title);
   }
 
   /**
@@ -199,6 +217,28 @@ public class VideoUpload {
 
   public String getStoragePath() {
     return storagePath;
+  }
+
+  public Long getWeekId() {
+    return weekId;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getDuration() {
+    return duration;
+  }
+
+  /**
+   * 동영상 길이를 설정한다.
+   *
+   * @param duration 동영상 길이 (예: "45:23")
+   */
+  public void setDuration(final String duration) {
+    this.duration = duration;
+    this.updatedAt = LocalDateTime.now();
   }
 
   public LocalDateTime getCreatedAt() {

--- a/springProject/src/main/java/com/teambind/springproject/domain/upload/service/UploadCompletionService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/upload/service/UploadCompletionService.java
@@ -1,13 +1,15 @@
 package com.teambind.springproject.domain.upload.service;
 
+import com.teambind.springproject.domain.content.entity.WeekContent;
+import com.teambind.springproject.domain.content.repository.WeekContentRepository;
 import com.teambind.springproject.domain.upload.entity.VideoUpload;
 import com.teambind.springproject.domain.upload.repository.VideoUploadRepository;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Map;
 import java.util.UUID;
 import me.desair.tus.server.TusFileUploadService;
 import me.desair.tus.server.upload.UploadInfo;
@@ -27,16 +29,22 @@ public class UploadCompletionService {
 
   private final TusFileUploadService tusService;
   private final VideoUploadRepository uploadRepository;
+  private final WeekContentRepository weekContentRepository;
   private final String storagePath;
+  private final String baseUrl;
 
   public UploadCompletionService(
       final TusFileUploadService tusService,
       final VideoUploadRepository uploadRepository,
-      @Value("${video.upload.storage-path:/tmp/video-uploads}") final String storagePath
+      final WeekContentRepository weekContentRepository,
+      @Value("${video.upload.storage-path:/tmp/video-uploads}") final String storagePath,
+      @Value("${video.stream.base-url:}") final String baseUrl
   ) {
     this.tusService = tusService;
     this.uploadRepository = uploadRepository;
+    this.weekContentRepository = weekContentRepository;
     this.storagePath = storagePath;
+    this.baseUrl = baseUrl;
   }
 
   /**
@@ -59,7 +67,12 @@ public class UploadCompletionService {
 
       // DB 업데이트
       String tusUploadId = extractUploadId(uploadUri);
-      updateUploadRecord(tusUploadId, finalPath);
+      VideoUpload upload = updateUploadRecord(tusUploadId, finalPath);
+
+      // week_contents 테이블에 등록
+      if (upload != null && upload.getWeekId() != null) {
+        createWeekContent(upload);
+      }
 
       // TUS 임시 파일 정리
       tusService.deleteUpload(uploadUri);
@@ -91,16 +104,24 @@ public class UploadCompletionService {
       filename = "unknown";
     }
 
+    // TUS 메타데이터에서 weekId, title 추출
+    Map<String, String> metadata = uploadInfo.getMetadata();
+    Long weekId = extractLongMetadata(metadata, "weekId");
+    String title = extractStringMetadata(metadata, "title", filename);
+
     VideoUpload upload = VideoUpload.create(
         tusUploadId,
         userId,
         filename,
         uploadInfo.getLength(),
-        uploadInfo.getFileMimeType()
+        uploadInfo.getFileMimeType(),
+        weekId,
+        title
     );
 
     uploadRepository.save(upload);
-    log.debug("업로드 메타데이터 저장: tusUploadId={}, filename={}", tusUploadId, filename);
+    log.debug("업로드 메타데이터 저장: tusUploadId={}, filename={}, weekId={}, title={}",
+        tusUploadId, filename, weekId, title);
   }
 
   /**
@@ -144,12 +165,65 @@ public class UploadCompletionService {
     return targetPath.toString();
   }
 
-  private void updateUploadRecord(final String tusUploadId, final String storagePath) {
-    uploadRepository.findByTusUploadId(tusUploadId)
-        .ifPresent(upload -> {
+  private VideoUpload updateUploadRecord(final String tusUploadId, final String storagePath) {
+    return uploadRepository.findByTusUploadId(tusUploadId)
+        .map(upload -> {
           upload.complete(storagePath);
-          uploadRepository.save(upload);
-        });
+          return uploadRepository.save(upload);
+        })
+        .orElse(null);
+  }
+
+  private void createWeekContent(final VideoUpload upload) {
+    // 스트리밍 URL 생성
+    String contentUrl = buildStreamUrl(upload.getId());
+
+    // 표시 순서 계산
+    Integer maxOrder = weekContentRepository.findMaxDisplayOrderByWeekId(upload.getWeekId());
+    Integer displayOrder = maxOrder + 1;
+
+    // WeekContent 생성 및 저장
+    WeekContent weekContent = WeekContent.createVideo(
+        upload.getWeekId(),
+        upload.getTitle(),
+        contentUrl,
+        upload.getDuration(),
+        displayOrder
+    );
+
+    weekContentRepository.save(weekContent);
+    log.info("WeekContent 생성: weekId={}, title={}, contentUrl={}",
+        upload.getWeekId(), upload.getTitle(), contentUrl);
+  }
+
+  private String buildStreamUrl(final Long videoUploadId) {
+    if (baseUrl != null && !baseUrl.isEmpty()) {
+      return baseUrl + "/api/v1/videos/stream/" + videoUploadId;
+    }
+    return "/api/v1/videos/stream/" + videoUploadId;
+  }
+
+  private Long extractLongMetadata(final Map<String, String> metadata, final String key) {
+    if (metadata == null || !metadata.containsKey(key)) {
+      return null;
+    }
+    try {
+      return Long.parseLong(metadata.get(key));
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private String extractStringMetadata(
+      final Map<String, String> metadata,
+      final String key,
+      final String defaultValue
+  ) {
+    if (metadata == null || !metadata.containsKey(key)) {
+      return defaultValue;
+    }
+    String value = metadata.get(key);
+    return (value != null && !value.isEmpty()) ? value : defaultValue;
   }
 
   private String extractUploadId(final String uploadUri) {


### PR DESCRIPTION
## Summary
- WeekContent 엔티티 및 리포지토리 생성
- VideoUpload에 weekId, title, duration 필드 추가
- 업로드 완료 시 week_contents 테이블에 자동 등록
- 비디오 스트리밍 API 엔드포인트 구현 (Range 요청 지원)

## 동작 흐름
1. 교수자가 TUS 업로드 시 메타데이터에 weekId, title 포함
2. 업로드 완료 시 VideoUpload 레코드 저장
3. week_contents 테이블에 content_url로 `/api/v1/videos/stream/{videoId}` 등록
4. 학생이 해당 URL로 비디오 시청

## Test plan
- [ ] TUS 업로드 시 weekId, title 메타데이터 전달 테스트
- [ ] 업로드 완료 후 week_contents 테이블 INSERT 확인
- [ ] 비디오 스트리밍 API Range 요청 테스트