### PR TITLE
콘텐츠 학습 완료 시 Redis Pub/Sub 이벤트 발행 #29

### DIFF
--- a/springProject/src/main/java/com/teambind/springproject/domain/learning/service/LearningRateService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/learning/service/LearningRateService.java
@@ -2,6 +2,7 @@ package com.teambind.springproject.domain.learning.service;
 
 import com.teambind.springproject.domain.fraud.repository.WatchedSegmentRepository;
 import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import com.teambind.springproject.domain.progress.event.ContentCompletedPublisher;
 import com.teambind.springproject.domain.progress.repository.StudentContentProgressRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,18 +20,21 @@ import java.util.Optional;
 public class LearningRateService {
 	
 	private static final Logger log = LoggerFactory.getLogger(LearningRateService.class);
-	
+
 	private final WatchedSegmentRepository segmentRepository;
 	private final StudentContentProgressRepository progressRepository;
+	private final ContentCompletedPublisher contentCompletedPublisher;
 	private final int completionThreshold;
-	
+
 	public LearningRateService(
 			final WatchedSegmentRepository segmentRepository,
 			final StudentContentProgressRepository progressRepository,
+			final ContentCompletedPublisher contentCompletedPublisher,
 			@Value("${learning.completion-threshold:90}") final int completionThreshold
 	) {
 		this.segmentRepository = segmentRepository;
 		this.progressRepository = progressRepository;
+		this.contentCompletedPublisher = contentCompletedPublisher;
 		this.completionThreshold = completionThreshold;
 	}
 	
@@ -135,19 +139,24 @@ public class LearningRateService {
 	) {
 		Optional<StudentContentProgress> progressOpt =
 				progressRepository.findByContentIdAndStudentId(contentId, userId);
-		
+
 		if (progressOpt.isEmpty()) {
 			log.debug("진행 기록 없음: userId={}, contentId={}", userId, contentId);
 			return;
 		}
-		
+
 		StudentContentProgress progress = progressOpt.get();
-		
+
 		// 학습률 기반으로 진행률 업데이트
-		progress.updateLearningRate(learningRate, completionThreshold);
-		
+		boolean justCompleted = progress.updateLearningRate(learningRate, completionThreshold);
+
 		progressRepository.save(progress);
-		
+
+		// 완료 이벤트 발행
+		if (justCompleted) {
+			contentCompletedPublisher.publish(userId, contentId, progress.getCompletedAt());
+		}
+
 		log.debug("진행 상황 업데이트: userId={}, contentId={}, rate={}%, completed={}",
 				userId, contentId, learningRate, progress.getIsCompleted());
 	}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/entity/StudentContentProgress.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/entity/StudentContentProgress.java
@@ -90,8 +90,9 @@ public class StudentContentProgress {
 	 * @param positionSeconds      현재 시청 위치 (초)
 	 * @param totalDurationSeconds 전체 영상 길이 (초)
 	 * @param completionThreshold  완료 기준 퍼센트 (예: 90)
+	 * @return 이번 호출로 완료 처리가 발생했으면 true
 	 */
-	public void updateProgress(
+	public boolean updateProgress(
 			final Integer positionSeconds,
 			final Integer totalDurationSeconds,
 			final int completionThreshold
@@ -99,18 +100,20 @@ public class StudentContentProgress {
 		this.lastPositionSeconds = positionSeconds;
 		this.lastAccessedAt = LocalDateTime.now();
 		this.accessCount++;
-		
+
 		// 진행률 계산
 		if (totalDurationSeconds > 0) {
 			int newPercentage = (int) ((positionSeconds * 100.0) / totalDurationSeconds);
 			this.progressPercentage = Math.min(Math.max(newPercentage, this.progressPercentage), 100);
 		}
-		
+
 		// 완료 처리
 		if (!this.isCompleted && this.progressPercentage >= completionThreshold) {
 			this.isCompleted = true;
 			this.completedAt = LocalDateTime.now();
+			return true;
 		}
+		return false;
 	}
 	
 	/**
@@ -127,19 +130,22 @@ public class StudentContentProgress {
 	 *
 	 * @param learningRate        학습률 (0-100)
 	 * @param completionThreshold 완료 기준 퍼센트
+	 * @return 이번 호출로 완료 처리가 발생했으면 true
 	 */
-	public void updateLearningRate(final int learningRate, final int completionThreshold) {
+	public boolean updateLearningRate(final int learningRate, final int completionThreshold) {
 		// 학습률이 기존 진행률보다 높을 때만 업데이트
 		if (learningRate > this.progressPercentage) {
 			this.progressPercentage = learningRate;
 		}
 		this.lastAccessedAt = LocalDateTime.now();
-		
+
 		// 완료 처리
 		if (!this.isCompleted && this.progressPercentage >= completionThreshold) {
 			this.isCompleted = true;
 			this.completedAt = LocalDateTime.now();
+			return true;
 		}
+		return false;
 	}
 	
 	// Getters

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/event/ContentCompletedEvent.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/event/ContentCompletedEvent.java
@@ -1,0 +1,26 @@
+package com.teambind.springproject.domain.progress.event;
+
+import java.time.LocalDateTime;
+
+/**
+ * 콘텐츠 학습 완료 이벤트.
+ * Redis Pub/Sub으로 발행되는 메시지 DTO.
+ */
+public record ContentCompletedEvent(
+		Long studentId,
+		Long contentId,
+		Long weekId,
+		Long courseId,
+		LocalDateTime completedAt
+) {
+
+	public static ContentCompletedEvent of(
+			final Long studentId,
+			final Long contentId,
+			final Long weekId,
+			final Long courseId,
+			final LocalDateTime completedAt
+	) {
+		return new ContentCompletedEvent(studentId, contentId, weekId, courseId, completedAt);
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/event/ContentCompletedPublisher.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/event/ContentCompletedPublisher.java
@@ -1,0 +1,95 @@
+package com.teambind.springproject.domain.progress.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teambind.springproject.domain.content.repository.WeekContentRepository;
+import com.teambind.springproject.domain.week.repository.CourseWeekRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+/**
+ * 콘텐츠 학습 완료 이벤트 발행 서비스.
+ * Redis Pub/Sub으로 이벤트를 발행한다.
+ */
+@Service
+public class ContentCompletedPublisher {
+
+	private static final Logger log = LoggerFactory.getLogger(ContentCompletedPublisher.class);
+	private static final String CHANNEL = "attendance:content-completed";
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final WeekContentRepository weekContentRepository;
+	private final CourseWeekRepository courseWeekRepository;
+	private final ObjectMapper objectMapper;
+
+	public ContentCompletedPublisher(
+			final RedisTemplate<String, Object> redisTemplate,
+			final WeekContentRepository weekContentRepository,
+			final CourseWeekRepository courseWeekRepository,
+			final ObjectMapper objectMapper
+	) {
+		this.redisTemplate = redisTemplate;
+		this.weekContentRepository = weekContentRepository;
+		this.courseWeekRepository = courseWeekRepository;
+		this.objectMapper = objectMapper;
+	}
+
+	/**
+	 * 콘텐츠 학습 완료 이벤트를 발행한다.
+	 *
+	 * @param studentId   학생 ID
+	 * @param contentId   콘텐츠 ID
+	 * @param completedAt 완료 시각
+	 */
+	public void publish(
+			final Long studentId,
+			final Long contentId,
+			final LocalDateTime completedAt
+	) {
+		try {
+			// weekId 조회
+			Long weekId = weekContentRepository.findById(contentId)
+					.map(content -> content.getWeekId())
+					.orElse(null);
+
+			if (weekId == null) {
+				log.warn("콘텐츠를 찾을 수 없습니다: contentId={}", contentId);
+				return;
+			}
+
+			// courseId 조회
+			Long courseId = courseWeekRepository.findById(weekId)
+					.map(week -> week.getCourseId())
+					.orElse(null);
+
+			if (courseId == null) {
+				log.warn("주차를 찾을 수 없습니다: weekId={}", weekId);
+				return;
+			}
+
+			// 이벤트 생성 및 발행
+			ContentCompletedEvent event = ContentCompletedEvent.of(
+					studentId,
+					contentId,
+					weekId,
+					courseId,
+					completedAt
+			);
+
+			String message = objectMapper.writeValueAsString(event);
+			redisTemplate.convertAndSend(CHANNEL, message);
+
+			log.info("콘텐츠 완료 이벤트 발행: channel={}, studentId={}, contentId={}, weekId={}, courseId={}",
+					CHANNEL, studentId, contentId, weekId, courseId);
+
+		} catch (JsonProcessingException e) {
+			log.error("이벤트 직렬화 실패: studentId={}, contentId={}", studentId, contentId, e);
+		} catch (Exception e) {
+			log.error("이벤트 발행 실패: studentId={}, contentId={}", studentId, contentId, e);
+		}
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/progress/service/ProgressService.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/progress/service/ProgressService.java
@@ -4,6 +4,7 @@ import com.teambind.springproject.domain.learning.service.LearningRateService;
 import com.teambind.springproject.domain.progress.dto.ProgressReportRequest;
 import com.teambind.springproject.domain.progress.dto.ProgressResponse;
 import com.teambind.springproject.domain.progress.entity.StudentContentProgress;
+import com.teambind.springproject.domain.progress.event.ContentCompletedPublisher;
 import com.teambind.springproject.domain.progress.repository.StudentContentProgressRepository;
 import com.teambind.springproject.domain.session.entity.WatchSession;
 import com.teambind.springproject.domain.session.repository.WatchSessionRepository;
@@ -22,19 +23,22 @@ public class ProgressService {
 	private final StudentContentProgressRepository progressRepository;
 	private final WatchSessionRepository sessionRepository;
 	private final LearningRateService learningRateService;
+	private final ContentCompletedPublisher contentCompletedPublisher;
 	private final int completionThreshold;
 	private final long sessionTimeoutSeconds;
-	
+
 	public ProgressService(
 			final StudentContentProgressRepository progressRepository,
 			final WatchSessionRepository sessionRepository,
 			final LearningRateService learningRateService,
+			final ContentCompletedPublisher contentCompletedPublisher,
 			@Value("${learning.completion-threshold:90}") final int completionThreshold,
 			@Value("${watch.session.timeout-seconds:30}") final long sessionTimeoutSeconds
 	) {
 		this.progressRepository = progressRepository;
 		this.sessionRepository = sessionRepository;
 		this.learningRateService = learningRateService;
+		this.contentCompletedPublisher = contentCompletedPublisher;
 		this.completionThreshold = completionThreshold;
 		this.sessionTimeoutSeconds = sessionTimeoutSeconds;
 	}
@@ -65,14 +69,23 @@ public class ProgressService {
 				request.contentId(),
 				session.getUserId()
 		);
-		
-		progress.updateProgress(
+
+		boolean justCompleted = progress.updateProgress(
 				request.currentPositionSeconds(),
 				request.totalDurationSeconds(),
 				completionThreshold
 		);
-		
+
 		progressRepository.save(progress);
+
+		// 완료 이벤트 발행
+		if (justCompleted) {
+			contentCompletedPublisher.publish(
+					session.getUserId(),
+					request.contentId(),
+					progress.getCompletedAt()
+			);
+		}
 		
 		// 학습률 기반 진행률 업데이트 (부정 시청 제외)
 		learningRateService.calculateAndUpdateLearningRate(

--- a/springProject/src/main/java/com/teambind/springproject/domain/week/entity/CourseWeek.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/week/entity/CourseWeek.java
@@ -1,0 +1,45 @@
+package com.teambind.springproject.domain.week.entity;
+
+import jakarta.persistence.*;
+
+/**
+ * 강좌 주차 엔티티 (읽기 전용).
+ * LMS DB의 course_weeks 테이블과 매핑.
+ */
+@Entity
+@Table(name = "course_weeks")
+public class CourseWeek {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "course_id", nullable = false)
+	private Long courseId;
+
+	@Column(name = "week_number", nullable = false)
+	private Integer weekNumber;
+
+	@Column(name = "title", length = 200)
+	private String title;
+
+	protected CourseWeek() {
+	}
+
+	// Getters
+	public Long getId() {
+		return id;
+	}
+
+	public Long getCourseId() {
+		return courseId;
+	}
+
+	public Integer getWeekNumber() {
+		return weekNumber;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+}

--- a/springProject/src/main/java/com/teambind/springproject/domain/week/repository/CourseWeekRepository.java
+++ b/springProject/src/main/java/com/teambind/springproject/domain/week/repository/CourseWeekRepository.java
@@ -1,0 +1,20 @@
+package com.teambind.springproject.domain.week.repository;
+
+import com.teambind.springproject.domain.week.entity.CourseWeek;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 강좌 주차 리포지토리 (읽기 전용).
+ */
+public interface CourseWeekRepository extends JpaRepository<CourseWeek, Long> {
+
+	/**
+	 * 주차 ID로 강좌 주차를 조회한다.
+	 *
+	 * @param id 주차 ID
+	 * @return CourseWeek
+	 */
+	Optional<CourseWeek> findById(Long id);
+}


### PR DESCRIPTION
## 개요
`student_content_progress.is_completed`가 `true`로 변경될 때 Redis Pub/Sub으로 이벤트를 발행합니다.

## 변경 사항
- CourseWeek 읽기 전용 엔티티 추가 (courseId 조회용)
- ContentCompletedEvent DTO 생성
- ContentCompletedPublisher 서비스 구현
- StudentContentProgress 엔티티 수정 (완료 여부 반환)
- ProgressService, LearningRateService에서 완료 시 이벤트 발행

## Redis Channel
`attendance:content-completed`

## 메시지 포맷 (JSON)
```json
{
  "studentId": 20250101003,
  "contentId": 70,
  "weekId": 68,
  "courseId": 50,
  "completedAt": "2025-12-19T09:48:46"
}
```

## 영향도
| 서버 | 변경 사항 |
|------|----------|
| Video Streaming Server | Redis Publish 로직 추가 |
| Core API Server | Redis Subscribe로 이벤트 수신 |

Closes #29